### PR TITLE
feat: Add search keyword highlighting in orange color

### DIFF
--- a/src/sidepanel/sidepanel.css
+++ b/src/sidepanel/sidepanel.css
@@ -737,6 +737,12 @@ body {
     border-radius: 2px;
 }
 
+.highlight-search {
+    background-color: #ffe0b2;
+    padding: 1px 2px;
+    border-radius: 2px;
+}
+
 /* 不一致バナー */
 .conflict-banner {
     background-color: #fff3cd;

--- a/src/sidepanel/sidepanel.ts
+++ b/src/sidepanel/sidepanel.ts
@@ -715,11 +715,12 @@ function renderCurrentReference() {
         allDecisionsDiv.classList.add('hidden');
     }
 
-    refTitle.innerHTML = highlightText(ref.title);
+    const searchKeyword = searchInput.value.trim();
+    refTitle.innerHTML = highlightText(ref.title, searchKeyword);
     refAuthors.textContent = ref.authors || '';
     refYear.textContent = ref.year?.toString() || '';
     refJournal.textContent = ref.journal || '';
-    refAbstract.innerHTML = highlightText(ref.abstract || '(抄録なし)');
+    refAbstract.innerHTML = highlightText(ref.abstract || '(抄録なし)', searchKeyword);
 
     if (ref.doi) {
         refDoi.href = `https://doi.org/${ref.doi}`;
@@ -1104,9 +1105,15 @@ function escapeHtml(text: string): string {
 /**
  * テキスト内のキーワードをハイライト
  */
-function highlightText(text: string): string {
+function highlightText(text: string, searchKeyword?: string): string {
     if (!text) return '';
     let result = escapeHtml(text);
+
+    // 検索キーワード（橙）- 優先度最低
+    if (searchKeyword && searchKeyword.trim()) {
+        const regex = createSmartRegex(searchKeyword.trim());
+        result = result.replace(regex, '<mark class="highlight-search">$1</mark>');
+    }
 
     // 除外キーワード（赤）
     for (const kw of highlightKeywords.exclude) {


### PR DESCRIPTION
- Add .highlight-search CSS class with orange background (#ffe0b2)
- Modify highlightText() function to accept optional search keyword parameter
- Update renderCurrentReference() to pass search keyword to highlighting
- Search keywords are highlighted with lower priority than include/exclude keywords

Closes the issue raised in Slack thread requesting search keyword highlighting in abstract with a color distinct from green (include) and red (exclude).