### PR TITLE
feat: Add settings screen with auto-navigation toggle

### DIFF
--- a/src/sidepanel/sidepanel.css
+++ b/src/sidepanel/sidepanel.css
@@ -925,3 +925,72 @@ input:focus+.slider {
 input:checked+.slider:before {
     transform: translateX(16px);
 }
+
+/* ログインヘッダー */
+.login-header {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 12px;
+}
+
+.btn-icon {
+    background: transparent;
+    border: none;
+    font-size: 20px;
+    padding: 8px;
+    cursor: pointer;
+    border-radius: 6px;
+    transition: background 0.2s;
+}
+
+.btn-icon:hover {
+    background-color: #f1f3f4;
+}
+
+/* 設定画面 */
+.settings-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.settings-header h2 {
+    margin-bottom: 0;
+}
+
+.settings-content {
+    padding: 8px 0;
+}
+
+.setting-item {
+    margin-bottom: 16px;
+    padding: 12px;
+    background: #f8f9fa;
+    border-radius: 6px;
+}
+
+.setting-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #333;
+    cursor: pointer;
+    user-select: none;
+}
+
+.setting-label input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+}
+
+.setting-description {
+    margin-top: 8px;
+    margin-left: 26px;
+    font-size: 12px;
+    color: #666;
+    line-height: 1.5;
+}

--- a/src/sidepanel/sidepanel.html
+++ b/src/sidepanel/sidepanel.html
@@ -28,6 +28,9 @@
 
             <!-- ログインセクション（未ログイン時のみ表示） -->
             <div id="login-section" class="login-section">
+                <div class="login-header">
+                    <button id="settings-btn" class="btn btn-icon" title="設定">⚙️</button>
+                </div>
                 <button id="login-btn" class="btn btn-primary btn-large">
                     Googleアカウントでログイン
                 </button>
@@ -210,6 +213,27 @@
             <div id="source-filters-section" class="source-filters-section">
                 <h4>インポート元ファイル</h4>
                 <div id="source-file-list" class="source-file-list"></div>
+            </div>
+        </section>
+
+        <!-- 設定画面セクション -->
+        <section id="settings-section" class="section hidden">
+            <div class="settings-header">
+                <h2>設定</h2>
+                <button id="close-settings-btn" class="btn btn-outline btn-small">閉じる</button>
+            </div>
+
+            <div class="settings-content">
+                <div class="setting-item">
+                    <label class="setting-label">
+                        <input type="checkbox" id="auto-navigate-checkbox" checked>
+                        <span>判断後に自動的に次の文献に遷移する</span>
+                    </label>
+                    <p class="setting-description">
+                        オフにすると、Include/Exclude/Maybeボタンをクリックしても次の文献に自動的に遷移しません。
+                        「次へ」ボタンで手動で遷移できます。
+                    </p>
+                </div>
             </div>
         </section>
     </div>

--- a/src/sidepanel/sidepanel.ts
+++ b/src/sidepanel/sidepanel.ts
@@ -39,6 +39,7 @@ let isKeyOpened = false;  // キーオープン状態
 let isAdmin = false;      // 管理者権限
 let sourceFiles: Set<string> = new Set();
 let selectedSourceFiles: Set<string> = new Set();
+let autoNavigateAfterDecision = true;  // 判断後に自動的に次の文献に遷移するかどうか
 
 // DOM要素
 const sourceFileListDiv = document.getElementById('source-file-list') as HTMLElement;
@@ -167,9 +168,18 @@ const projectSection = document.getElementById('project-section') as HTMLElement
 const loginBtn = document.getElementById('login-btn') as HTMLButtonElement;
 const logoutBtn = document.getElementById('logout-btn') as HTMLButtonElement;
 
+// 設定セクション
+const settingsSection = document.getElementById('settings-section') as HTMLElement;
+const settingsBtn = document.getElementById('settings-btn') as HTMLButtonElement;
+const closeSettingsBtn = document.getElementById('close-settings-btn') as HTMLButtonElement;
+const autoNavigateCheckbox = document.getElementById('auto-navigate-checkbox') as HTMLInputElement;
+
 async function initApp() {
     try {
         showLoading(true);
+
+        // 設定を読み込み
+        await loadUserSettings();
 
         // サイレント認証を試行
         try {
@@ -280,6 +290,11 @@ function setupEventListeners() {
     // ログイン
     loginBtn.addEventListener('click', handleLogin);
     logoutBtn.addEventListener('click', handleLogout);
+
+    // 設定
+    settingsBtn.addEventListener('click', showSettings);
+    closeSettingsBtn.addEventListener('click', hideSettings);
+    autoNavigateCheckbox.addEventListener('change', handleAutoNavigateChange);
 
     // 接続
     connectBtn.addEventListener('click', handleConnect);
@@ -887,8 +902,10 @@ async function handleDecision(decision: 'include' | 'exclude' | 'maybe') {
     // UIを即座に更新
     renderCurrentReference();
 
-    // 次の文献へ（保存を待たずに移動）
-    navigate(1);
+    // 次の文献へ（自動遷移設定が有効な場合のみ）
+    if (autoNavigateAfterDecision) {
+        navigate(1);
+    }
 
     // APIに保存（バックグラウンド、UIブロックしない）
     apiSaveDecision(spreadsheetId, decisionObj)
@@ -1539,5 +1556,67 @@ function escapeCSVField(value: string): string {
     return value;
 }
 
+
+// ========== 設定関連関数 ==========
+
+/**
+ * 設定画面を表示
+ */
+function showSettings() {
+    configSection.classList.add('hidden');
+    screeningSection.classList.add('hidden');
+    settingsSection.classList.remove('hidden');
+}
+
+/**
+ * 設定画面を閉じる
+ */
+function hideSettings() {
+    settingsSection.classList.add('hidden');
+
+    // 前に表示していた画面に戻る
+    if (spreadsheetId) {
+        screeningSection.classList.remove('hidden');
+    } else {
+        configSection.classList.remove('hidden');
+    }
+}
+
+/**
+ * 自動遷移設定の変更を処理
+ */
+async function handleAutoNavigateChange() {
+    autoNavigateAfterDecision = autoNavigateCheckbox.checked;
+    await saveUserSettings();
+    showToast(autoNavigateAfterDecision
+        ? '判断後に自動的に次の文献に遷移します'
+        : '判断後は手動で遷移してください');
+}
+
+/**
+ * ユーザー設定を保存
+ */
+async function saveUserSettings() {
+    await chrome.storage.local.set({
+        autoNavigateAfterDecision
+    });
+}
+
+/**
+ * ユーザー設定を読み込み
+ */
+async function loadUserSettings() {
+    const result = await chrome.storage.local.get(['autoNavigateAfterDecision']);
+
+    // デフォルトはtrue（自動遷移する）
+    if (result.autoNavigateAfterDecision !== undefined) {
+        autoNavigateAfterDecision = result.autoNavigateAfterDecision;
+    } else {
+        autoNavigateAfterDecision = true;
+    }
+
+    // チェックボックスの状態を更新
+    autoNavigateCheckbox.checked = autoNavigateAfterDecision;
+}
 
 export { };


### PR DESCRIPTION
- Add settings button (⚙️) to login screen header
- Create settings section with auto-navigation option
- Implement setting to control automatic navigation after decision
- Default behavior: automatically navigate to next reference after decision
- Users can disable auto-navigation via settings
- Settings are persisted in Chrome storage