### PR TITLE
Save LLM threshold decisions to Google Sheets

### DIFF
--- a/src/sidepanel/features/llm/batch.ts
+++ b/src/sidepanel/features/llm/batch.ts
@@ -349,7 +349,7 @@ export function renderDistributionChart() {
 }
 
 /**
- * 閾値を確定して保存
+ * 閾値を確定して判断をGoogleスプレッドシートに保存
  */
 export async function handleConfirmThreshold() {
     const threshold = parseFloat(dom.thresholdSlider.value);
@@ -393,7 +393,7 @@ export async function handleConfirmThreshold() {
             llm_include_threshold: threshold,
         });
 
-        showToast('閾値を確定して保存しました');
+        showToast('閾値を確定してGoogleスプレッドシートに保存しました');
 
         // データを再読み込み
         if (_loadDataAndShowScreening) {

--- a/src/sidepanel/sidepanel.html
+++ b/src/sidepanel/sidepanel.html
@@ -455,7 +455,7 @@
                 </div>
 
                 <button id="confirm-threshold-btn" class="btn btn-primary btn-full">
-                    💾 閾値を確定して保存
+                    💾 閾値を確定して判断をGoogleスプレッドシートに保存
                 </button>
                 <p class="threshold-note">※ 確定後、Decisionsシートに判定が記録されます</p>
             </div>


### PR DESCRIPTION
保存先がわかりにくかったため、ボタンテキストを
「閾値を確定して保存」から
「閾値を確定して判断をGoogleスプレッドシートに保存」に変更