### PR TITLE
fix: AI Evidenceハイライトをクリックで抄録フィルタリングを有効化

### DIFF
--- a/src/sidepanel/features/screening/filters.ts
+++ b/src/sidepanel/features/screening/filters.ts
@@ -287,6 +287,10 @@ export function handleTermClick(e: MouseEvent) {
     } else if (target.classList.contains('highlight-search')) {
         const term = target.textContent;
         if (term) addTermFilter(term, 'include');
+    } else if (target.classList.contains('highlight-evidence')) {
+        // AI Evidenceハイライトをクリックした場合もフィルターに追加
+        const term = target.textContent;
+        if (term) addTermFilter(term, 'include');
     }
 }
 

--- a/src/sidepanel/styles/keywords.css
+++ b/src/sidepanel/styles/keywords.css
@@ -171,5 +171,10 @@
 .highlight-evidence {
     background-color: #fff3cd;
     border-bottom: 2px solid #fbbc04;
-    cursor: help;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.highlight-evidence:hover {
+    opacity: 0.7;
 }


### PR DESCRIPTION
- handleTermClick関数にhighlight-evidenceクラスのハンドリングを追加
- AI Evidenceハイライトをクリック時にincludeタイプのタームフィルターを追加
- CSSでhighlight-evidenceにcursor: pointerとホバーエフェクトを追加
- Human Review画面でAI判定のEvidenceハイライトがクリック可能になり、 他のハイライト（include/exclude/search）と同様にフィルタリングが適用される