### PR TITLE
fix: 初期画面のURL残留を解消し最近一覧から再選択させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ npm run watch
 - 判定保存に失敗した場合はキューに退避し、オンライン復帰時や次回保存時に再送します
 - 100件未満は `chrome.storage.local`、100件以上は IndexedDB に保存します
 
+## LLMモデル履歴
+
+- 既定のLLMモデルは `gemini-flash-lite-latest` です。
+- UIで選べるモデルは `gemini-flash-lite-latest` と `gemini-flash-latest` の2つです。
+- Run の集約は、呼び出しに指定したモデルID（`requested_model` / 既存の `model`）で行います。
+- Gemini API応答に含まれる実モデルバージョンは、`model_version` として `LLM_Executions` / `LLM_Runs` / 判定noteに保存します。
+- latest系エイリアスの実体が更新されても、同じ呼び出し設定として扱い、実バージョン差は履歴ログで確認します。
+
 ## 手動レビュー時の戻る挙動
 
 - `未判定` フィルタで手動レビューしている間は、`戻る` / `←` で直近5件のレビュー履歴を新しい順にたどれます

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tiab-review-plugin",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "description": "TiAb Review Plugin - Chrome Extension for Systematic Review Screening",
     "private": true,
     "scripts": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -885,6 +885,49 @@
   "llm_historyEmpty": {
     "message": "No execution history"
   },
+  "llm_recoverOrphansBtn": {
+    "message": "🛟 Recover orphaned decisions"
+  },
+  "llm_recoverOrphansChecking": {
+    "message": "Searching for orphaned decisions..."
+  },
+  "llm_recoverOrphansNoneFound": {
+    "message": "No orphaned decisions found"
+  },
+  "llm_recoverOrphansDialogTitle": {
+    "message": "Recover orphaned decisions"
+  },
+  "llm_recoverOrphansDialogBody": {
+    "message": "Found $1 orphaned execution(s). Adding rows to LLM_Executions enables the threshold UI for these batches. Rows are written with is_active=false, so you must select them explicitly via the radio button.",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "llm_recoverOrphansListItem": {
+    "message": "$1 (decisions: $2)",
+    "placeholders": {
+      "1": { "content": "$1" },
+      "2": { "content": "$2" }
+    }
+  },
+  "llm_recoverOrphansConfirmBtn": {
+    "message": "Recover"
+  },
+  "llm_recoverOrphansCancelBtn": {
+    "message": "Cancel"
+  },
+  "llm_recoverOrphansSuccess": {
+    "message": "Recovered $1 history row(s). Open them in execution history to set the threshold.",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "llm_recoverOrphansError": {
+    "message": "Recovery error: $1",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
   "llm_historyBatch": {
     "message": "Batch"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -649,7 +649,7 @@
     "message": "Model:"
   },
   "llm_modelFlash3": {
-    "message": "Gemini 3 Flash (Recommended, High Accuracy)"
+    "message": "Gemini 3 Flash"
   },
   "llm_modelLite": {
     "message": "Gemini 2.5 Flash Lite (Cost-effective)"
@@ -1552,7 +1552,7 @@
     "message": "Help"
   },
   "llm_tip_model": {
-    "message": "Pick the Gemini model used for screening.\n• Gemini 3 Flash: recommended. Higher accuracy.\n• Gemini 2.5 Flash Lite: faster and cheaper, good for large batches.\nWhen in doubt, use Gemini 3 Flash."
+    "message": "Pick the Gemini model used for screening.\n• Gemini Flash-Lite Latest: recommended. Calls the latest low-cost, low-latency Flash-Lite endpoint.\n• Gemini Flash Latest: calls the latest Flash endpoint when accuracy matters more.\nThe model version that actually generated the response is saved in the history log."
   },
   "llm_tip_outputLanguage": {
     "message": "Sets the language of the AI's reasoning (reason) output.\nRecommended: match your everyday working language."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -898,7 +898,7 @@
     "message": "Recover orphaned decisions"
   },
   "llm_recoverOrphansDialogBody": {
-    "message": "Found $1 orphaned execution(s). Adding rows to LLM_Executions enables the threshold UI for these batches. Rows are written with is_active=false, so you must select them explicitly via the radio button.",
+    "message": "Found $1 orphaned execution(s). Batch rows will be added to LLM_Executions and automatically grouped into LLM_Runs. After recovery, you can set thresholds per Run in the history UI (Runs remain inactive until explicitly enabled).",
     "placeholders": {
       "1": { "content": "$1" }
     }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -885,6 +885,49 @@
   "llm_historyEmpty": {
     "message": "実行履歴がありません"
   },
+  "llm_recoverOrphansBtn": {
+    "message": "🛟 孤立判定を復旧"
+  },
+  "llm_recoverOrphansChecking": {
+    "message": "孤立した判定を検索中..."
+  },
+  "llm_recoverOrphansNoneFound": {
+    "message": "孤立した判定はありません"
+  },
+  "llm_recoverOrphansDialogTitle": {
+    "message": "孤立した判定の復旧"
+  },
+  "llm_recoverOrphansDialogBody": {
+    "message": "$1件の孤立した実行が見つかりました。LLM_Executions に履歴行を追加すると、閾値設定UIから操作できるようになります（is_active=false で書き込むので、ラジオで明示的に有効化する必要があります）。",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "llm_recoverOrphansListItem": {
+    "message": "$1 （判定行: $2件）",
+    "placeholders": {
+      "1": { "content": "$1" },
+      "2": { "content": "$2" }
+    }
+  },
+  "llm_recoverOrphansConfirmBtn": {
+    "message": "復旧する"
+  },
+  "llm_recoverOrphansCancelBtn": {
+    "message": "キャンセル"
+  },
+  "llm_recoverOrphansSuccess": {
+    "message": "$1件の履歴行を復旧しました。実行履歴で閾値を設定してください。",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
+  "llm_recoverOrphansError": {
+    "message": "復旧中にエラーが発生しました: $1",
+    "placeholders": {
+      "1": { "content": "$1" }
+    }
+  },
   "llm_historyBatch": {
     "message": "バッチ"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -649,7 +649,7 @@
     "message": "モデル:"
   },
   "llm_modelFlash3": {
-    "message": "Gemini 3 Flash (推奨・高精度)"
+    "message": "Gemini 3 Flash"
   },
   "llm_modelLite": {
     "message": "Gemini 2.5 Flash Lite (コスト重視)"
@@ -1552,7 +1552,7 @@
     "message": "ヘルプ"
   },
   "llm_tip_model": {
-    "message": "判定に使うGeminiモデルを選びます。\n• Gemini 3 Flash: 推奨。判定精度が高め。\n• Gemini 2.5 Flash Lite: 高速・低コスト。大量処理向け。\n迷ったらGemini 3 Flashを選んでください。"
+    "message": "判定に使うGeminiモデルを選びます。\n• Gemini Flash-Lite Latest: 推奨。低コスト・高速なFlash-Lite系の最新モデルを呼び出します。\n• Gemini Flash Latest: 精度重視のFlash系最新モデルを呼び出します。\n実際に応答したモデルバージョンは履歴ログに保存されます。"
   },
   "llm_tip_outputLanguage": {
     "message": "AIが出力する判定理由(reason)の言語を切り替えます。\n推奨: 普段使う言語に合わせる。"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -898,7 +898,7 @@
     "message": "孤立した判定の復旧"
   },
   "llm_recoverOrphansDialogBody": {
-    "message": "$1件の孤立した実行が見つかりました。LLM_Executions に履歴行を追加すると、閾値設定UIから操作できるようになります（is_active=false で書き込むので、ラジオで明示的に有効化する必要があります）。",
+    "message": "$1件の孤立した実行が見つかりました。LLM_Executions に Batch 行を追加し、自動的に LLM_Runs にグループ化します。実行後は履歴UIから Run 単位で閾値設定が可能になります（Run は明示的に有効化するまで使用されません）。",
     "placeholders": {
       "1": { "content": "$1" }
     }

--- a/src/lib/gemini-api.ts
+++ b/src/lib/gemini-api.ts
@@ -1,6 +1,6 @@
 // gemini-api.ts - Gemini API クライアント
 
-import type { LlmScreeningOutput, LlmCriteria, ApiKeyTestResult, ApiTier, UsageMetadata } from './types';
+import type { LlmScreeningOutput, LlmCriteria, ApiKeyTestResult, ApiTier, UsageMetadata, LlmModelResponseMetadata } from './types';
 import { getEffectiveApiKey } from './storage';
 import { t } from './i18n';
 
@@ -47,18 +47,26 @@ export interface CriteriaConversionOptions {
  * デフォルト設定
  */
 export const DEFAULT_MODEL_CONFIG: GeminiModelConfig = {
-    model: 'gemini-3-flash-preview',
-    temperature: 1.0,
-    topP: 0.95,
-    thinkingLevel: 'LOW',
+    model: 'gemini-flash-lite-latest',
+    temperature: 0,
 };
 
 /**
- * コスト重視設定 (Flash Lite)
+ * 安定版 Flash-Lite 設定
  */
 export const LITE_MODEL_CONFIG: GeminiModelConfig = {
-    model: 'gemini-2.5-flash-lite',
+    model: 'gemini-3.1-flash-lite',
     temperature: 0,
+};
+
+/**
+ * Flash latest 設定
+ */
+export const FLASH_MODEL_CONFIG: GeminiModelConfig = {
+    model: 'gemini-flash-latest',
+    temperature: 1.0,
+    topP: 0.95,
+    thinkingLevel: 'LOW',
 };
 
 /**
@@ -158,7 +166,7 @@ async function callGeminiApi<T>(
     responseSchema: object,
     config: GeminiModelConfig = DEFAULT_MODEL_CONFIG,
     timeoutMs: number = 90000
-): Promise<{ result: T; usageMetadata: UsageMetadata }> {
+): Promise<{ result: T; usageMetadata: UsageMetadata; responseMetadata: LlmModelResponseMetadata }> {
     const apiKey = await getEffectiveApiKey();
     if (!apiKey) {
         throw new GeminiApiError(t('error_geminiApiKeyMissing'), {
@@ -271,6 +279,11 @@ async function callGeminiApi<T>(
             thoughtsTokenCount: rawUsage.thoughtsTokenCount || 0,
             totalTokenCount: rawUsage.totalTokenCount || 0,
         };
+        const metadataSource = [...responses].reverse().find(res => res?.modelVersion || res?.responseId) || {};
+        const responseMetadata: LlmModelResponseMetadata = {
+            modelVersion: metadataSource.modelVersion || lastResponse?.modelVersion,
+            responseId: metadataSource.responseId || lastResponse?.responseId,
+        };
 
         // 全レスポンスからテキストを結合（Thinking部分を除く）
         let fullText = '';
@@ -297,13 +310,13 @@ async function callGeminiApi<T>(
 
         // JSONパース
         try {
-            return { result: JSON.parse(fullText) as T, usageMetadata };
+            return { result: JSON.parse(fullText) as T, usageMetadata, responseMetadata };
         } catch (e) {
             // Thinking modelの場合、テキストにJSON以外の内容が混ざることがある
             const jsonMatch = fullText.match(/\{[\s\S]*\}/);
             if (jsonMatch) {
                 try {
-                    return { result: JSON.parse(jsonMatch[0]) as T, usageMetadata };
+                    return { result: JSON.parse(jsonMatch[0]) as T, usageMetadata, responseMetadata };
                 } catch (e2) {
                     throw new GeminiApiError(t('error_geminiJsonParseFailed'), {
                         code: 'json_parse_failed',
@@ -387,7 +400,7 @@ export async function screenReference(
     screeningPrompt: string,
     config: GeminiModelConfig = DEFAULT_MODEL_CONFIG,
     outputLanguage: string = 'ja'
-): Promise<{ output: LlmScreeningOutput; usageMetadata: UsageMetadata }> {
+): Promise<{ output: LlmScreeningOutput; usageMetadata: UsageMetadata; responseMetadata: LlmModelResponseMetadata }> {
     const prompt = `${screeningPrompt}
 
 ## 対象文献
@@ -405,12 +418,12 @@ ${abstract || '(抄録なし)'}
 
 注意: quoteはtitleまたはabstract内の正確な部分文字列でなければなりません。`;
 
-    const { result, usageMetadata } = await callGeminiApi<LlmScreeningOutput>(
+    const { result, usageMetadata, responseMetadata } = await callGeminiApi<LlmScreeningOutput>(
         prompt,
         SCREENING_OUTPUT_SCHEMA,
         config
     );
-    return { output: result, usageMetadata };
+    return { output: result, usageMetadata, responseMetadata };
 }
 
 /**
@@ -546,19 +559,19 @@ export interface ModelOption {
 
 /**
  * 利用可能なモデル一覧
- * 実験結果に基づき、Flash 3.0 (Thinking LOW) を推奨
+ * 既定は latest エイリアス。実応答の modelVersion は履歴ログへ保存する。
  * 各モデルに固有のパラメータを含む
  */
 export const AVAILABLE_MODELS: ModelOption[] = [
     {
-        id: 'gemini-3-flash-preview',
-        name: 'Gemini 3 Flash',
-        config: { temperature: 1.0, topP: 0.95, thinkingLevel: 'LOW' }
+        id: 'gemini-flash-lite-latest',
+        name: 'Gemini Flash-Lite Latest',
+        config: { temperature: 0 }
     },
     {
-        id: 'gemini-2.5-flash-lite',
-        name: 'Gemini 2.5 Flash Lite',
-        config: { temperature: 0 }
+        id: 'gemini-flash-latest',
+        name: 'Gemini Flash Latest',
+        config: { temperature: 1.0, topP: 0.95, thinkingLevel: 'LOW' }
     },
 ];
 

--- a/src/lib/llm-processor.ts
+++ b/src/lib/llm-processor.ts
@@ -138,6 +138,10 @@ export interface BatchProcessOptions {
      * 閾値確認 UI を出さずに即時確定される。
      */
     applyThreshold?: number;
+    // 呼び出し側で事前に execution_id を生成して LLM_Executions 行を先書きする運用のため、
+    // 同じ id/timestamp をバッチ内でも使えるように受け取れるようにする
+    executionId?: string;
+    timestamp?: Date;
 }
 
 /**
@@ -267,8 +271,8 @@ export async function processBatch(
     references: Reference[],
     options: BatchProcessOptions
 ): Promise<BatchProcessResult> {
-    const timestamp = new Date();
-    const executionId = generateLlmReviewerId(options.model, timestamp);
+    const timestamp = options.timestamp ?? new Date();
+    const executionId = options.executionId ?? generateLlmReviewerId(options.model, timestamp);
 
     const progress: LlmBatchProgress = {
         total: references.length,

--- a/src/lib/llm-processor.ts
+++ b/src/lib/llm-processor.ts
@@ -11,6 +11,7 @@ import type {
     LlmCriteria,
     RateLimitConfig,
     UsageMetadata,
+    LlmModelResponseMetadata,
 } from './types';
 import { RATE_LIMIT_PAID } from './types';
 import { screenReference, GeminiModelConfig } from './gemini-api';
@@ -44,12 +45,16 @@ export function createLlmDecisionNote(
     executionId: string,
     model: string,
     output: LlmScreeningOutput,
-    usageMetadata?: UsageMetadata
+    usageMetadata?: UsageMetadata,
+    responseMetadata?: LlmModelResponseMetadata
 ): LlmDecisionNote {
     return {
         type: 'llm',
         execution_id: executionId,
         model,
+        requested_model: model,
+        model_version: responseMetadata?.modelVersion,
+        response_id: responseMetadata?.responseId,
         include_probability: output.include_probability,
         reasons: output.reasons,
         evidence: output.evidence,
@@ -72,6 +77,7 @@ export function createLlmFallbackDecisionNote(
         type: 'llm',
         execution_id: executionId,
         model,
+        requested_model: model,
         include_probability: 1.0,
         reasons: [`LLM 出力が解析できませんでした (${errorMessage})`],
         evidence: [],
@@ -153,13 +159,17 @@ export interface BatchProcessResult {
     successCount: number;       // 通常の成功件数（フォールバックは含まない）
     failCount: number;          // decision を作れなかった件数（abort 等）
     fallbackCount: number;      // LLM 出力解析失敗で確率 1.0 として保存した件数
+    modelVersions: string[];
+    responseIds: string[];
+    resolvedModelVersion?: string;
+    latestResponseId?: string;
     decisions: Decision[];
     failedRefIds: string[];     // リトライ対象（完全失敗 + フォールバック保存）
     fallbackRefIds: string[];   // フォールバック保存された ref_id（再判定したい場合の参照用）
 }
 
 type ProcessOutcome =
-    | { success: true; decision: Decision; refId: string; isFallback: boolean }
+    | { success: true; decision: Decision; refId: string; isFallback: boolean; responseMetadata?: LlmModelResponseMetadata }
     | { success: false; decision: null; refId: string };
 
 /**
@@ -181,7 +191,7 @@ async function processWithRetry(
     let lastErrorMessage = 'Unknown error';
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
-            const { output, usageMetadata } = await screenReference(
+            const { output, usageMetadata, responseMetadata } = await screenReference(
                 ref.title,
                 ref.abstract || '',
                 screeningPrompt,
@@ -189,7 +199,7 @@ async function processWithRetry(
                 outputLanguage
             );
 
-            const noteData = createLlmDecisionNote(executionId, model, output, usageMetadata);
+            const noteData = createLlmDecisionNote(executionId, model, output, usageMetadata, responseMetadata);
             const decision: Decision = {
                 decision_id: crypto.randomUUID(),
                 ref_id: ref.ref_id,
@@ -201,7 +211,7 @@ async function processWithRetry(
                 client_version: getClientVersion('-llm'),
             };
 
-            return { success: true, decision, refId: ref.ref_id, isFallback: false };
+            return { success: true, decision, refId: ref.ref_id, isFallback: false, responseMetadata };
         } catch (error) {
             lastErrorMessage = error instanceof Error ? error.message : 'Unknown error';
             if (attempt < maxRetries) {
@@ -286,6 +296,9 @@ export async function processBatch(
     const allDecisions: Decision[] = [];
     const fallbackRefIds: string[] = [];
     const pendingForSave: Decision[] = [];
+    const modelVersions = new Set<string>();
+    const responseIds = new Set<string>();
+    let latestResponseId: string | undefined;
 
     const modelConfig: GeminiModelConfig = {
         model: options.model,
@@ -350,6 +363,13 @@ export async function processBatch(
                 }
                 allDecisions.push(result.decision);
                 pendingForSave.push(result.decision);
+                if (result.responseMetadata?.modelVersion) {
+                    modelVersions.add(result.responseMetadata.modelVersion);
+                }
+                if (result.responseMetadata?.responseId) {
+                    responseIds.add(result.responseMetadata.responseId);
+                    latestResponseId = result.responseMetadata.responseId;
+                }
             } else {
                 progress.failed++;
             }
@@ -397,6 +417,10 @@ export async function processBatch(
         successCount: progress.succeeded,
         failCount: progress.failed,
         fallbackCount: progress.parseErrorFallback,
+        modelVersions: Array.from(modelVersions),
+        responseIds: Array.from(responseIds),
+        resolvedModelVersion: Array.from(modelVersions).join(', '),
+        latestResponseId,
         decisions: allDecisions,
         failedRefIds,
         fallbackRefIds,
@@ -509,6 +533,7 @@ export function createLlmExecution(
         execution_type: executionType,
         timestamp: new Date().toISOString(),
         model,
+        requested_model: model,
         temperature,
         topP,
         thinkingLevel,

--- a/src/lib/sheets-api.ts
+++ b/src/lib/sheets-api.ts
@@ -20,7 +20,8 @@ const LLM_EXECUTIONS_HEADERS = [
     'temperature', 'topP', 'thinkingLevel',  // Model parameters
     'criteria_snapshot', 'screening_prompt', 'include_threshold',
     'target_count', 'include_count', 'exclude_count',
-    'status', 'is_active', 'run_id'
+    'status', 'is_active', 'run_id',
+    'requested_model', 'model_version', 'response_id'
 ];
 
 // LLM_Runs シートのヘッダー（Run = config_hash 単位の論理実行）
@@ -28,7 +29,8 @@ const LLM_RUNS_HEADERS = [
     'run_id', 'config_hash', 'created_at', 'model',
     'temperature', 'topP', 'thinkingLevel',
     'criteria_snapshot', 'screening_prompt',
-    'include_threshold', 'status', 'is_active'
+    'include_threshold', 'status', 'is_active',
+    'requested_model', 'model_version', 'response_id'
 ];
 
 // デフォルトハイライトキーワード（RCT フィルタリング想定）
@@ -1343,8 +1345,8 @@ async function trySetKeyOpened(spreadsheetId: string, opened: boolean) {
  */
 export const DEFAULT_LLM_CONFIG: LlmConfig = {
     llm_enabled: false,
-    llm_model: 'gemini-3-flash-preview',
-    llm_temperature: 1.0,
+    llm_model: 'gemini-flash-lite-latest',
+    llm_temperature: 0,
     llm_thinking: 'low',
     llm_protocol_text: '',
     llm_criteria: null,
@@ -1586,6 +1588,9 @@ export async function saveLlmExecution(spreadsheetId: string, execution: LlmExec
         execution.status,
         execution.is_active ? 'true' : 'false',
         execution.run_id ?? '',
+        execution.requested_model ?? execution.model,
+        execution.model_version ?? '',
+        execution.response_id ?? '',
     ];
 
     await appendRows(spreadsheetId, LLM_EXECUTIONS_SHEET, [row]);
@@ -1971,6 +1976,9 @@ async function migrateLegacyExecutionsToRuns(
                 config_hash: hash,
                 created_at: oldest.timestamp,
                 model: sourceForAttrs.model,
+                requested_model: sourceForAttrs.requested_model ?? sourceForAttrs.model,
+                model_version: sourceForAttrs.model_version,
+                response_id: sourceForAttrs.response_id,
                 temperature: sourceForAttrs.temperature,
                 topP: sourceForAttrs.topP,
                 thinkingLevel: sourceForAttrs.thinkingLevel,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -108,6 +108,9 @@ export interface LlmExecution {
     execution_type: 'prompt_generation' | 'batch_screening';
     timestamp: string;
     model: string;
+    requested_model?: string;
+    model_version?: string;
+    response_id?: string;
     // Model parameters (for traceability)
     temperature?: number;
     topP?: number;
@@ -137,6 +140,9 @@ export interface LlmRun {
     config_hash: string;              // "v1:sha256(...)" 形式
     created_at: string;               // 配下バッチ最古の timestamp
     model: string;
+    requested_model?: string;
+    model_version?: string;
+    response_id?: string;
     temperature?: number;
     topP?: number;
     thinkingLevel?: string;
@@ -177,12 +183,23 @@ export interface UsageMetadata {
 }
 
 /**
+ * Gemini API response metadata
+ */
+export interface LlmModelResponseMetadata {
+    modelVersion?: string;
+    responseId?: string;
+}
+
+/**
  * LLM判定のnoteフィールドに保存する構造
  */
 export interface LlmDecisionNote {
     type: 'llm';
     execution_id: string;
     model: string;
+    requested_model?: string;
+    model_version?: string;
+    response_id?: string;
     include_probability: number;
     reasons: string[];
     evidence: LlmEvidence[];
@@ -279,6 +296,34 @@ export const BATCH_PROFILES: Record<ManualTier, BatchProfile> = {
  * 対応していない (tier, model) の組み合わせは BATCH_PROFILES の値が使われる。
  */
 export const BATCH_PROFILE_OVERRIDES: Record<string, Partial<Record<ManualTier, BatchProfile>>> = {
+    'gemini-flash-lite-latest': {
+        tier1: {
+            rate: { concurrency: 30, delayBetweenRequests: 80 },   // 実効 ~450 RPM (cap 4,000)
+            saveBatchSize: 30,
+        },
+        tier2: {
+            rate: { concurrency: 60, delayBetweenRequests: 50 },   // 実効 ~900 RPM (cap 10,000)
+            saveBatchSize: 60,
+        },
+        tier3: {
+            rate: { concurrency: 100, delayBetweenRequests: 30 },  // 実効 ~1,500 RPM (cap 30,000)
+            saveBatchSize: 100,
+        },
+    },
+    'gemini-3.1-flash-lite': {
+        tier1: {
+            rate: { concurrency: 30, delayBetweenRequests: 80 },   // 実効 ~450 RPM (cap 4,000)
+            saveBatchSize: 30,
+        },
+        tier2: {
+            rate: { concurrency: 60, delayBetweenRequests: 50 },   // 実効 ~900 RPM (cap 10,000)
+            saveBatchSize: 60,
+        },
+        tier3: {
+            rate: { concurrency: 100, delayBetweenRequests: 30 },  // 実効 ~1,500 RPM (cap 30,000)
+            saveBatchSize: 100,
+        },
+    },
     'gemini-2.5-flash-lite': {
         tier1: {
             rate: { concurrency: 30, delayBetweenRequests: 80 },   // 実効 ~450 RPM (cap 4,000)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extName__",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "default_locale": "ja",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxleBKT1/T3XzlZhHEB2GjyDLIkQ8exz7ZfAx7IvDB6PMWnrwJ6Cv9SPqAJ9FxF3OSGcobjwQzYt+xBbXVZgBuvcj1mvIekDZ3jH0QeZH8HWVKAjHkGJdiAMocrR1TsOO9bAUyFiYv/R8/4/qk+b9jve0aosK2PPb80+p4GekjhDVXRVfg6Q7gKjbZitR2g/MGCQH+qHOAusyYrjoE62luQC9EfIPYxAJ4XFtxsfhOcDal990Ln9w8pchQGHjoWDc+D74LHhl2umc+9GbEXj78m5fO2CRJgTU+ETH/vIdmDi4QgmzLMkw2GWAXr/TSUenIigMAdexpDYPL+nqHk8LCwIDAQAB",
     "description": "__MSG_extDescription__",

--- a/src/sidepanel/dom.ts
+++ b/src/sidepanel/dom.ts
@@ -214,6 +214,7 @@ const domElements = {
     get distributionChart() { return getElement<HTMLElement>('distribution-chart'); },
     get confirmThresholdBtn() { return getElement<HTMLButtonElement>('confirm-threshold-btn'); },
     get executionHistory() { return getElement<HTMLElement>('execution-history'); },
+    get recoverOrphansBtn() { return getElement<HTMLButtonElement>('recover-orphans-btn'); },
 
     // ========== Reference Detail (for event delegation) ==========
     get referenceDetail() { return document.getElementById('reference-detail'); },

--- a/src/sidepanel/features/llm/batch.ts
+++ b/src/sidepanel/features/llm/batch.ts
@@ -34,6 +34,7 @@ import {
     previewThresholdCounts,
     applyThresholdToDecisions,
     createLlmExecution,
+    generateLlmReviewerId,
 } from '../../../lib/llm-processor';
 import { DEFAULT_SCREENING_PROMPT } from '../../../lib/prompt-templates';
 import { getModelConfig } from '../../../lib/gemini-api';
@@ -193,12 +194,16 @@ export async function handleStartBatch() {
     state.setBatchAbortController(abortController);
     state.setCurrentBatchDecisions([]);
 
+    // 中断・エラー時にも finally で履歴行を実件数で更新するため、
+    // try 開始前に execution_id を保持する変数を用意しておく
+    let executionId: string | null = null;
+    const spreadsheetId = state.spreadsheetId;
+
     try {
         // 選択されたモデルの設定を取得（モデル ID はプロファイル解決にも使う）
         const modelConfig = getModelConfig(dom.llmModelSelect.value);
 
         const profile = await resolveBatchProfile(modelConfig.model);
-        const spreadsheetId = state.spreadsheetId;
         const llmConfig = state.llmConfig;
 
         if (profile === BATCH_PROFILES.free) {
@@ -244,6 +249,38 @@ export async function handleStartBatch() {
             await saveLlmRun(spreadsheetId, newRun);
         }
 
+        // バッチ開始前に execution_id を生成し、Batch 行（LLM_Executions）を先書きする。
+        // こうしておくと、最後の数件でリトライ失敗・Stop・サイドパネル閉鎖などが起きても
+        // Decisions シートに書かれた LLM 判定が「Batch 行のない孤立データ」になるのを防げる。
+        // Run/Batch 分離後は閾値・status・is_active は LLM_Runs 側が正なので、
+        // ここでは固定値（threshold=0, status='pending', is_active=false）で書き、後段で読み飛ばされる。
+        const timestamp = new Date();
+        executionId = generateLlmReviewerId(modelConfig.model, timestamp);
+        state.setCurrentExecutionId(executionId);
+
+        const initialExecution = createLlmExecution(
+            executionId,
+            'batch_screening',
+            modelConfig.model,
+            llmConfig.llm_criteria,
+            dom.screeningPromptInput.value,
+            0,
+            targetRefs.length,      // target_count は実件数で finally に再更新
+            0,
+            0,
+            'pending',
+            false,                  // Batch 行の is_active は Run 側が管理するため常に false
+            modelConfig.temperature,
+            modelConfig.topP,
+            modelConfig.thinkingLevel,
+        );
+        // execution_id 内の timestamp とシート上の timestamp 列を揃えておく
+        initialExecution.timestamp = timestamp.toISOString();
+        initialExecution.run_id = runId;
+        await saveLlmExecution(spreadsheetId, initialExecution);
+        // 履歴UIに「pending」として即時反映
+        await loadExecutionHistory();
+
         const result = await processBatch(targetRefs, {
             batchSize: profile.saveBatchSize,
             screeningPrompt,
@@ -255,6 +292,10 @@ export async function handleStartBatch() {
             outputLanguage: dom.llmLanguageSelect.value,
             rateLimitConfig: profile.rate,
             abortSignal: abortController.signal,
+            // 事前生成した execution_id / timestamp を共有させて、
+            // Decisions 側の reviewer_id と LLM_Executions 側の execution_id を一致させる
+            executionId,
+            timestamp,
             onProgress: updateBatchProgress,
             onSaveBatch: async (decisions) => {
                 await appendDecisions(spreadsheetId, decisions);
@@ -264,8 +305,6 @@ export async function handleStartBatch() {
             // confirmed Run 配下のバッチは保存時点で include/exclude を確定させる
             applyThreshold: runThreshold ?? undefined,
         });
-
-        state.setCurrentExecutionId(result.executionId);
 
         // 失敗したref_idを保存
         state.setFailedRefIds(result.failedRefIds);
@@ -280,28 +319,8 @@ export async function handleStartBatch() {
 
         // 完了後のUI更新
         if (!abortController.signal.aborted) {
-            // Batch row を保存。
-            // Run/Batch 分離後は閾値・status・is_active は LLM_Runs 側を正とするため、
-            // LLM_Executions 側の値は固定値（threshold=0, status='pending', is_active=false）で
-            // 書き込み、読み取り時は無視される。
-            const execution = createLlmExecution(
-                result.executionId,
-                'batch_screening',
-                modelConfig.model,
-                llmConfig.llm_criteria,
-                dom.screeningPromptInput.value,
-                0,
-                result.processedCount,
-                0,
-                0,
-                'pending',
-                false,
-                modelConfig.temperature,
-                modelConfig.topP,
-                modelConfig.thinkingLevel
-            );
-            execution.run_id = runId;
-            await saveLlmExecution(spreadsheetId, execution);
+            // Batch 行は pre-write 済みなのでここでの再保存は不要。
+            // Run/Batch 分離後、閾値・status・is_active は LLM_Runs 側を正とする。
 
             // confirmed Run なら、Run を active 化して閾値 UI を出さない
             if (isImmediate && runThreshold !== null) {
@@ -348,9 +367,25 @@ export async function handleStartBatch() {
         dom.startBatchBtn.classList.remove('hidden');
         dom.stopBatchBtn.classList.add('hidden');
         state.setBatchAbortController(null);
+
+        // pre-write した履歴行の target_count を、実際に保存できた判定件数で更新する。
+        // 中断・エラー・成功のいずれでもここに来るので、履歴行と Decisions シートの件数が
+        // 食い違わないようにする最後の保険。失敗しても黙って続行する。
+        if (executionId) {
+            try {
+                const savedCount = state.currentBatchDecisions.length;
+                await updateLlmExecution(spreadsheetId, executionId, {
+                    target_count: savedCount,
+                });
+                await loadExecutionHistory();
+            } catch (err) {
+                console.warn('[handleStartBatch] target_count update failed:', err);
+            }
+        }
+
         // バッチで判定済みになった文献を「未判定」カウントから除外するため再読込
         // （中断・エラー時も部分的に保存されている可能性があるので必ず実行）
-        await refreshReferencesAfterBatch(state.spreadsheetId);
+        await refreshReferencesAfterBatch(spreadsheetId);
     }
 }
 

--- a/src/sidepanel/features/llm/batch.ts
+++ b/src/sidepanel/features/llm/batch.ts
@@ -203,6 +203,7 @@ export async function handleStartBatch() {
     // 中断・エラー時にも finally で履歴行を実件数で更新するため、
     // try 開始前に execution_id を保持する変数を用意しておく
     let executionId: string | null = null;
+    let batchResult: Awaited<ReturnType<typeof processBatch>> | null = null;
     const spreadsheetId = state.spreadsheetId;
 
     try {
@@ -241,6 +242,7 @@ export async function handleStartBatch() {
                 config_hash: configHash,
                 created_at: new Date().toISOString(),
                 model: modelConfig.model,
+                requested_model: modelConfig.model,
                 temperature: modelConfig.temperature,
                 topP: modelConfig.topP,
                 thinkingLevel: modelConfig.thinkingLevel,
@@ -311,6 +313,7 @@ export async function handleStartBatch() {
             // confirmed Run 配下のバッチは保存時点で include/exclude を確定させる
             applyThreshold: runThreshold ?? undefined,
         });
+        batchResult = result;
 
         // 失敗したref_idを保存
         state.setFailedRefIds(result.failedRefIds);
@@ -380,7 +383,19 @@ export async function handleStartBatch() {
                 const savedCount = state.currentBatchDecisions.length;
                 await updateLlmExecution(spreadsheetId, executionId, {
                     target_count: savedCount,
+                    model_version: batchResult?.resolvedModelVersion,
+                    response_id: batchResult?.latestResponseId,
                 });
+                const resolvedModelVersion = batchResult?.resolvedModelVersion;
+                if (resolvedModelVersion) {
+                    const run = await getRunForBatchId(spreadsheetId, executionId);
+                    if (run) {
+                        await updateLlmRun(spreadsheetId, run.run_id, {
+                            model_version: resolvedModelVersion,
+                            response_id: batchResult?.latestResponseId,
+                        });
+                    }
+                }
                 await loadExecutionHistory();
             } catch (err) {
                 console.warn('[handleStartBatch] target_count update failed:', err);
@@ -889,7 +904,9 @@ function appendRunCard(
     // モデル名は textContent で安全に流し込む
     const modelEl = card.querySelector('.run-model') as HTMLElement | null;
     if (modelEl) {
-        modelEl.textContent = run.model;
+        modelEl.textContent = run.model_version
+            ? `${run.model} / ${run.model_version}`
+            : run.model;
     }
 
     // ラジオ: クリックで Run を active 化

--- a/src/sidepanel/features/llm/batch.ts
+++ b/src/sidepanel/features/llm/batch.ts
@@ -158,6 +158,12 @@ export function updateBatchTargetCount() {
  * バッチ処理を開始
  */
 export async function handleStartBatch() {
+    // 直前バッチの post-batch refresh が走っている間は state.references が古いまま。
+    // ここで握っておかないと、同じ文献を次のバッチが重複して投げてしまう。
+    if (state.batchAbortController) {
+        return;
+    }
+
     const apiKey = await getEffectiveApiKey();
     if (!apiKey) {
         showToast(t('llm_apiKeyRequired'));
@@ -364,9 +370,7 @@ export async function handleStartBatch() {
         console.error('[handleStartBatch] Error:', error);
         showToast(t('llm_batchError', (error as Error).message));
     } finally {
-        dom.startBatchBtn.classList.remove('hidden');
         dom.stopBatchBtn.classList.add('hidden');
-        state.setBatchAbortController(null);
 
         // pre-write した履歴行の target_count を、実際に保存できた判定件数で更新する。
         // 中断・エラー・成功のいずれでもここに来るので、履歴行と Decisions シートの件数が
@@ -385,7 +389,12 @@ export async function handleStartBatch() {
 
         // バッチで判定済みになった文献を「未判定」カウントから除外するため再読込
         // （中断・エラー時も部分的に保存されている可能性があるので必ず実行）
+        // Start ボタンと AbortController の解放は refresh 完了後にまとめて行う。
+        // 先に解放すると state.references が古いまま連続クリックされて、
+        // 直前のバッチ対象を重複して投げてしまう競合が起きる（重複の入口は冒頭の guard で塞ぐ）。
         await refreshReferencesAfterBatch(spreadsheetId);
+        state.setBatchAbortController(null);
+        dom.startBatchBtn.classList.remove('hidden');
     }
 }
 
@@ -404,6 +413,11 @@ export function handleStopBatch() {
  * 失敗した件をリトライ
  */
 export async function handleRetryFailed() {
+    // 直前バッチの後始末（refresh）と被ると state.references が古いまま走るので block する
+    if (state.batchAbortController) {
+        return;
+    }
+
     const failedRefIds = state.failedRefIds;
     if (failedRefIds.length === 0) {
         showToast(t('llm_retryNoTarget'));
@@ -486,10 +500,11 @@ export async function handleRetryFailed() {
         console.error('[handleRetryFailed] Error:', error);
         showToast(t('llm_retryError', (error as Error).message));
     } finally {
-        dom.startBatchBtn.classList.remove('hidden');
         dom.stopBatchBtn.classList.add('hidden');
-        state.setBatchAbortController(null);
+        // refresh 完了後にまとめて解放（handleStartBatch 側の guard と対になっている）
         await refreshReferencesAfterBatch(state.spreadsheetId);
+        state.setBatchAbortController(null);
+        dom.startBatchBtn.classList.remove('hidden');
     }
 }
 

--- a/src/sidepanel/features/llm/index.ts
+++ b/src/sidepanel/features/llm/index.ts
@@ -32,6 +32,7 @@ import {
     loadExecutionHistory,
     setLoadDataAndShowScreening as setLoadDataAndShowScreeningForBatch,
 } from './batch';
+import { handleRecoverOrphans } from './recovery';
 
 // Store互換レイヤー（Phase 5）
 import {
@@ -103,6 +104,9 @@ export function setupLlmEventListeners() {
     dom.thresholdSlider?.addEventListener('input', handleThresholdChange);
     dom.toggleDistributionBtn?.addEventListener('click', toggleDistributionChart);
     dom.confirmThresholdBtn?.addEventListener('click', handleConfirmThreshold);
+
+    // 孤立判定の復旧
+    dom.recoverOrphansBtn?.addEventListener('click', handleRecoverOrphans);
 
     // 折りたたみセクション
     document.querySelectorAll('.llm-card.collapsible .collapsible-header').forEach(header => {

--- a/src/sidepanel/features/llm/recovery.ts
+++ b/src/sidepanel/features/llm/recovery.ts
@@ -1,0 +1,293 @@
+/**
+ * 孤立判定の検出と復旧（Run/Batch 分離モデル対応）
+ *
+ * Decisions シートに `llm:` で始まる reviewer_id の判定行があるのに、
+ * LLM_Executions（Batch シート）に対応する execution_id の行がないケースを救う。
+ *
+ * 発生原因の例:
+ * - バッチ完了直前に Stop / サイドパネル閉鎖 / OAuth 失効などが発生し、
+ *   Batch 行の書き込みがスキップされた
+ * - 旧バージョンで判定したあと、新バージョンで履歴シートを期待するようになった
+ * - ユーザーが LLM_Executions シートを手動で消した
+ *
+ * 復旧フロー:
+ * 1. 孤立した execution_id ごとに Batch 行（LLM_Executions）を生成
+ * 2. `getLlmRuns()` を呼ぶことで既存の `migrateLegacyExecutionsToRuns()` が走り、
+ *    run_id 空の Batch 行が config_hash でグループ化されて Run 行が自動生成される
+ * 3. 履歴UIを再読込
+ */
+
+import { dom } from '../../dom';
+import { state } from '../../state';
+import {
+    getDecisions,
+    getLlmExecutions,
+    getLlmRuns,
+    saveLlmExecution,
+} from '../../../lib/sheets-api';
+import { createLlmExecution, parseLlmDecisionNote } from '../../../lib/llm-processor';
+import type { LlmExecution } from '../../../lib/types';
+import { showToast } from '../../ui/feedback';
+import { showModal, hideModal } from '../ml/dialogs';
+import { t } from '../../../lib/i18n';
+import { loadExecutionHistory } from './batch';
+
+/**
+ * 孤立した実行に関する情報
+ */
+export interface OrphanedExecutionInfo {
+    executionId: string;
+    model: string;
+    timestamp: string;        // ISO 8601。execution_id 内の `@` 以降から抽出
+    decisionCount: number;    // Decisions シート上で同 reviewer_id を持つ行数
+    promptVersion?: string;   // 判定行の note から抽出（任意）
+}
+
+/**
+ * `llm:{model}@{ISO_timestamp}` 形式から model と timestamp を分離
+ */
+function parseExecutionId(executionId: string): { model: string; timestamp: string } | null {
+    if (!executionId.startsWith('llm:')) return null;
+    const body = executionId.slice('llm:'.length);
+    const atIndex = body.lastIndexOf('@');
+    if (atIndex <= 0 || atIndex >= body.length - 1) return null;
+    const model = body.slice(0, atIndex);
+    const timestamp = body.slice(atIndex + 1);
+    return { model, timestamp };
+}
+
+/**
+ * LLM_Executions に Batch 行がない execution_id を Decisions から拾い上げる
+ */
+export async function findOrphanedExecutions(spreadsheetId: string): Promise<OrphanedExecutionInfo[]> {
+    console.log('[findOrphanedExecutions] Start');
+    const [allDecisions, existingExecutions] = await Promise.all([
+        getDecisions(spreadsheetId),
+        getLlmExecutions(spreadsheetId),
+    ]);
+    console.log('[findOrphanedExecutions] decisions=', allDecisions.length, 'executions=', existingExecutions.length);
+
+    const existingIds = new Set(existingExecutions.map((exec) => exec.execution_id));
+
+    // reviewer_id ごとに件数とサンプル note を集計
+    const buckets = new Map<string, { count: number; sampleNote?: string }>();
+    for (const { decision } of allDecisions) {
+        const id = decision.reviewer_id;
+        if (!id.startsWith('llm:')) continue;
+        if (existingIds.has(id)) continue;
+
+        const bucket = buckets.get(id) ?? { count: 0 };
+        bucket.count += 1;
+        if (!bucket.sampleNote && decision.note) {
+            bucket.sampleNote = decision.note;
+        }
+        buckets.set(id, bucket);
+    }
+
+    const orphans: OrphanedExecutionInfo[] = [];
+    for (const [executionId, { count, sampleNote }] of buckets) {
+        const parsed = parseExecutionId(executionId);
+        if (!parsed) {
+            // 異常な ID は無視（ログに残しておく）
+            console.warn('[findOrphanedExecutions] Skipping unparsable execution_id:', executionId);
+            continue;
+        }
+
+        let promptVersion: string | undefined;
+        if (sampleNote) {
+            const note = parseLlmDecisionNote(sampleNote);
+            promptVersion = note?.prompt_version;
+        }
+
+        orphans.push({
+            executionId,
+            model: parsed.model,
+            timestamp: parsed.timestamp,
+            decisionCount: count,
+            promptVersion,
+        });
+    }
+
+    // 新しい順に並べる
+    orphans.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    console.log('[findOrphanedExecutions] orphans=', orphans.length);
+    return orphans;
+}
+
+/**
+ * 復旧時に流用する既存の Batch（同モデル優先）を選ぶ
+ * - criteria_snapshot / screening_prompt / model parameters の補完元として使う
+ */
+function pickTemplateExecution(
+    executions: LlmExecution[],
+    model: string,
+): LlmExecution | null {
+    const batches = executions
+        .filter((exec) => exec.execution_type === 'batch_screening')
+        .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+    const sameModel = batches.find((exec) => exec.model === model);
+    return sameModel ?? batches[0] ?? null;
+}
+
+/**
+ * 孤立した execution_id に対して Batch 行（LLM_Executions）を再構築する
+ *
+ * - `run_id` は空にして保存する。後段の `getLlmRuns()` で自動的に Run へ束ねられる。
+ * - status='pending', is_active=false は Batch 行のダミー値（Run 側が正の値を持つ）
+ * - criteria_snapshot / screening_prompt / モデルパラメータは、同モデルの直近 Batch
+ *   から流用、なければ現在の llmConfig からフォールバック
+ */
+export async function recoverOrphanedExecutions(
+    spreadsheetId: string,
+    orphans: OrphanedExecutionInfo[],
+): Promise<number> {
+    if (orphans.length === 0) return 0;
+
+    console.log('[recoverOrphanedExecutions] Recovering', orphans.length, 'orphans');
+    const executions = await getLlmExecutions(spreadsheetId);
+    const llmConfig = state.llmConfig;
+    let recovered = 0;
+
+    for (const orphan of orphans) {
+        const template = pickTemplateExecution(executions, orphan.model);
+
+        const criteria = template?.criteria_snapshot ?? llmConfig?.llm_criteria ?? null;
+        const screeningPrompt = template?.screening_prompt ?? llmConfig?.llm_screening_prompt ?? '';
+        const temperature = template?.temperature;
+        const topP = template?.topP;
+        const thinkingLevel = template?.thinkingLevel;
+
+        const execution = createLlmExecution(
+            orphan.executionId,
+            'batch_screening',
+            orphan.model,
+            criteria,
+            screeningPrompt,
+            0,                              // include_threshold（Run 側が正）
+            orphan.decisionCount,           // target_count は実件数
+            0,
+            0,
+            'pending',                      // status は Run 側が正
+            false,                          // is_active は Run 側が正
+            temperature,
+            topP,
+            thinkingLevel,
+        );
+        // 並び順を整えるため、execution_id 内の timestamp と一致させる
+        execution.timestamp = orphan.timestamp;
+        // run_id は空のままにしておく → getLlmRuns() 内の自動移行が config_hash で
+        // グルーピングして Run を生成し、Batch の run_id を埋めてくれる
+        execution.run_id = '';
+
+        try {
+            await saveLlmExecution(spreadsheetId, execution);
+            recovered += 1;
+        } catch (err) {
+            console.error(`[recoverOrphanedExecutions] Failed to save ${orphan.executionId}:`, err);
+        }
+    }
+
+    console.log('[recoverOrphanedExecutions] Saved', recovered, 'Batch rows; triggering Run migration');
+
+    // 既存の自動移行を発火させる: getLlmRuns() 内部で
+    // migrateLegacyExecutionsToRuns() が走り、run_id 空の Batch 行を
+    // config_hash でグループ化して Run 行を新規作成する
+    try {
+        const runs = await getLlmRuns(spreadsheetId);
+        console.log('[recoverOrphanedExecutions] Runs after migration:', runs.length);
+    } catch (err) {
+        console.error('[recoverOrphanedExecutions] Run migration failed:', err);
+        // 移行失敗しても Batch 行は保存済みなので throw はしない
+    }
+
+    return recovered;
+}
+
+/**
+ * 「孤立判定を復旧」ボタンのクリックハンドラ
+ */
+export async function handleRecoverOrphans(): Promise<void> {
+    console.log('[handleRecoverOrphans] Clicked');
+    const btn = dom.recoverOrphansBtn;
+    const spreadsheetId = state.spreadsheetId;
+    if (!spreadsheetId) {
+        showToast(t('llm_recoverOrphansError', 'spreadsheetId missing'));
+        return;
+    }
+
+    btn.disabled = true;
+    try {
+        showToast(t('llm_recoverOrphansChecking'));
+        const orphans = await findOrphanedExecutions(spreadsheetId);
+
+        if (orphans.length === 0) {
+            showToast(t('llm_recoverOrphansNoneFound'));
+            return;
+        }
+
+        // モーダル本体: 件数概要 + 各 orphan の execution_id / 判定件数を一覧表示
+        const body = document.createElement('div');
+
+        const summary = document.createElement('p');
+        summary.textContent = t('llm_recoverOrphansDialogBody', String(orphans.length));
+        body.appendChild(summary);
+
+        const list = document.createElement('ul');
+        list.style.margin = '0.5em 0';
+        list.style.paddingLeft = '1.25em';
+        for (const orphan of orphans) {
+            const li = document.createElement('li');
+            li.textContent = t('llm_recoverOrphansListItem', [
+                orphan.executionId,
+                String(orphan.decisionCount),
+            ]);
+            list.appendChild(li);
+        }
+        body.appendChild(list);
+
+        // フッター: 復旧 / キャンセル
+        const footer = document.createElement('div');
+        footer.style.display = 'flex';
+        footer.style.gap = '0.5em';
+        footer.style.justifyContent = 'flex-end';
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.className = 'btn btn-outline';
+        cancelBtn.textContent = t('llm_recoverOrphansCancelBtn');
+        cancelBtn.onclick = () => hideModal();
+
+        const confirmBtn = document.createElement('button');
+        confirmBtn.className = 'btn btn-primary';
+        confirmBtn.textContent = t('llm_recoverOrphansConfirmBtn');
+        confirmBtn.onclick = async () => {
+            confirmBtn.disabled = true;
+            cancelBtn.disabled = true;
+            try {
+                const recovered = await recoverOrphanedExecutions(spreadsheetId, orphans);
+                hideModal();
+                showToast(t('llm_recoverOrphansSuccess', String(recovered)));
+                await loadExecutionHistory();
+            } catch (err) {
+                console.error('[handleRecoverOrphans] Recovery failed:', err);
+                showToast(t('llm_recoverOrphansError', (err as Error).message));
+                confirmBtn.disabled = false;
+                cancelBtn.disabled = false;
+            }
+        };
+
+        footer.appendChild(cancelBtn);
+        footer.appendChild(confirmBtn);
+
+        showModal({
+            title: t('llm_recoverOrphansDialogTitle'),
+            body,
+            footer,
+        });
+    } catch (err) {
+        console.error('[handleRecoverOrphans] Error:', err);
+        showToast(t('llm_recoverOrphansError', (err as Error).message));
+    } finally {
+        btn.disabled = false;
+    }
+}

--- a/src/sidepanel/features/project.ts
+++ b/src/sidepanel/features/project.ts
@@ -56,6 +56,10 @@ let _renderKeyStatus: (() => void) | null = null;
 let _renderReviewerFilter: (() => void) | null = null;
 let _renderAiHighlightToggle: (() => void) | null = null;
 
+// 最近使用したシート一覧の取得に成功したかどうか。
+// loadConfig で URL 入力欄にフォールバック表示するかの判定に使う。
+let _recentSheetsLoaded = false;
+
 export function setProjectDependencies(deps: {
     renderKeywords: () => void;
     renderSourceFilters: () => void;
@@ -74,13 +78,21 @@ export function setProjectDependencies(deps: {
 
 /**
  * 戻るボタン処理
+ *
+ * 初期画面に戻った際は URL 入力欄を空にし、最近使用したシート一覧を再取得して
+ * 直前に開いたスプレッドシートがドロップダウンから再選択されるようにする。
  */
-export function handleBack() {
+export async function handleBack() {
     // 状態をリセット（Store経由で両方に同期）
     syncResetForBack();
 
     // プロジェクト選択画面を表示（Store経由でrenderLayoutが自動更新）
     showProjectView();
+
+    // 最近一覧を再取得し、保存済み spreadsheetId をドロップダウン側に再選択させる
+    // 失敗時のフォールバック表示は loadConfig / loadRecentSheets 内で行う
+    await loadRecentSheets();
+    await loadConfig();
 }
 
 /**
@@ -147,6 +159,9 @@ export async function handleConnect() {
         // 設定を保存
         await chrome.storage.local.set({ spreadsheetId: resolvedId });
 
+        // 戻った際に URL 入力欄が残らないよう、ここで明示的にクリアしておく
+        dom.spreadsheetInput.value = '';
+
         // データを読み込んで画面切り替え
         await loadDataAndShowScreening();
     } catch (error) {
@@ -161,6 +176,7 @@ export async function handleConnect() {
  * 最近使用したスプレッドシートをドロップダウンに読み込み
  */
 export async function loadRecentSheets() {
+    _recentSheetsLoaded = false;
     try {
         dom.recentSheetsSelect.innerHTML = `<option value="">${t('project_loading')}</option>`;
 
@@ -173,6 +189,7 @@ export async function loadRecentSheets() {
             opt.value = '';
             opt.textContent = t('project_noSheets');
             dom.recentSheetsSelect.appendChild(opt);
+            _recentSheetsLoaded = true;
             return;
         }
 
@@ -188,6 +205,8 @@ export async function loadRecentSheets() {
             opt.textContent = sheet.name;
             dom.recentSheetsSelect.appendChild(opt);
         }
+
+        _recentSheetsLoaded = true;
     } catch (error) {
         console.error('Failed to load recent sheets:', error);
 
@@ -241,6 +260,9 @@ export async function handleCreateNew() {
 
         // 設定を保存
         await chrome.storage.local.set({ spreadsheetId: newId });
+
+        // 戻った際に URL 入力欄が残らないよう明示的にクリア
+        dom.spreadsheetInput.value = '';
 
         // 画面切り替え
         await loadDataAndShowScreening();
@@ -379,17 +401,30 @@ export async function loadDataAndShowScreening() {
 
 /**
  * 保存済み設定を読み込み
+ *
+ * 復元順序:
+ * 1. 最近使用したシート一覧にあればドロップダウンで選択
+ * 2. 一覧の取得に失敗している場合のみ、レアケース救済として URL 入力欄に表示
+ *    （成功取得時はドロップダウンを優先し、URL 入力欄は「手で入れる場所」として空のままにする）
  */
 export async function loadConfig() {
+    // 既存の値をクリアして毎回まっさらな状態から復元する
+    dom.spreadsheetInput.value = '';
+
     const result = await chrome.storage.local.get(['spreadsheetId']);
-    if (result.spreadsheetId) {
-        const hasOption = Array.from(dom.recentSheetsSelect.options)
-            .some((opt) => opt.value === result.spreadsheetId);
-        if (hasOption) {
-            dom.recentSheetsSelect.value = result.spreadsheetId;
-        } else {
-            dom.spreadsheetInput.value = result.spreadsheetId;
-        }
+    if (!result.spreadsheetId) {
+        dom.recentSheetsSelect.value = '';
+        return;
+    }
+
+    const hasOption = Array.from(dom.recentSheetsSelect.options)
+        .some((opt) => opt.value === result.spreadsheetId);
+
+    if (hasOption) {
+        dom.recentSheetsSelect.value = result.spreadsheetId;
+    } else if (!_recentSheetsLoaded) {
+        // 最近一覧の取得に失敗しているときだけ、URL 入力欄にフォールバック表示
+        dom.spreadsheetInput.value = result.spreadsheetId;
     }
 }
 

--- a/src/sidepanel/sidepanel.html
+++ b/src/sidepanel/sidepanel.html
@@ -367,8 +367,8 @@
                         <label data-i18n="llm_modelLabel"></label>
                         <span class="help-icon" data-i18n-tooltip="llm_tip_model" tabindex="0">?</span>
                         <select id="llm-model-select">
-                            <option value="gemini-3-flash-preview" selected data-i18n="llm_modelFlash3"></option>
-                            <option value="gemini-2.5-flash-lite" data-i18n="llm_modelLite"></option>
+                            <option value="gemini-flash-lite-latest" selected>Gemini Flash-Lite Latest</option>
+                            <option value="gemini-flash-latest">Gemini Flash Latest</option>
                         </select>
                     </div>
                     <div class="setting-row">

--- a/src/sidepanel/sidepanel.html
+++ b/src/sidepanel/sidepanel.html
@@ -537,6 +537,7 @@
                     <div id="execution-history" class="execution-history">
                         <p class="placeholder-text" data-i18n="llm_historyEmpty"></p>
                     </div>
+                    <button id="recover-orphans-btn" class="btn btn-outline btn-small" data-i18n="llm_recoverOrphansBtn"></button>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary

- 初期画面で URL から開いた後に戻ると、URL 入力欄に値が残ったままになる問題を修正
- `handleBack` で最近使用したスプレッドシート一覧を再取得し、保存済み `spreadsheetId` をドロップダウン側に自動選択させる
- `loadConfig` の URL 入力欄へのフォールバックは一覧取得失敗時のみに限定（通常運用では URL 欄は「手で入れる場所」として空のままになる）

## 変更ファイル

`src/sidepanel/features/project.ts` のみ (+44/-9):

| 関数 | 変更 |
| --- | --- |
| `handleBack` | `async` 化。state リセット→画面切替後に `loadRecentSheets()` → `loadConfig()` を再実行 |
| `loadRecentSheets` | 成否を `_recentSheetsLoaded` フラグで保持 |
| `loadConfig` | 冒頭で URL 入力欄を空にする。ドロップダウンに該当があれば選択、無い場合は一覧取得失敗時のみ URL 欄にフォールバック |
| `handleConnect` / `handleCreateNew` | 成功時に `dom.spreadsheetInput.value = ''` を明示 |

## 注意点

このブランチは `fix/llm-execution-row-pre-write` 由来のコミット 6 件 (LLM 関連) を含む。マージ時に main へ取り込まれることを確認してください。

## Test plan

- [ ] 初回 URL 貼付 → 接続 → 戻る で URL 欄が空、ドロップダウンに当該シートが選択済みになる
- [ ] 既存ドロップダウン選択 → 接続 → 戻る で URL 欄が空、ドロップダウンに選択値が残る
- [ ] ログアウト → 再ログイン後、URL 欄は空、ドロップダウンに前回シートが選択される
- [ ] Drive API が 401 等で失敗した時、URL 欄に前回 ID がフォールバック表示される（既存挙動維持）
- [ ] 新規作成 → 戻る で適切に動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)