### PR TITLE
fix: URLで開いたシートも初期画面ドロップダウンに表示

### DIFF
--- a/src/lib/sheets-api.ts
+++ b/src/lib/sheets-api.ts
@@ -188,6 +188,56 @@ export async function getRecentSpreadsheets(maxResults = 10): Promise<RecentSpre
 }
 
 /**
+ * ローカルに記録する「拡張機能で開いたシート」エントリ。
+ *
+ * OAuth スコープが drive.file のため、URL を貼り付けて開いたシートは Drive API の
+ * files.list には現れない。拡張機能内で接続/作成したシートはここに保存しておき、
+ * 初期画面のドロップダウンに合流させることで「最近開いた」一覧として再選択できる
+ * ようにする。
+ */
+export interface LocalRecentSheet {
+    id: string;
+    name: string;
+    lastUsedAt: string; // ISO 8601
+}
+
+const LOCAL_RECENT_SHEETS_KEY = 'localRecentSheets';
+const LOCAL_RECENT_SHEETS_MAX = 30;
+
+export async function getLocalRecentSheets(): Promise<LocalRecentSheet[]> {
+    try {
+        const result = await chrome.storage.local.get([LOCAL_RECENT_SHEETS_KEY]);
+        const raw = result[LOCAL_RECENT_SHEETS_KEY];
+        if (!Array.isArray(raw)) return [];
+        return raw
+            .filter((entry): entry is LocalRecentSheet =>
+                entry &&
+                typeof entry.id === 'string' &&
+                typeof entry.name === 'string' &&
+                typeof entry.lastUsedAt === 'string'
+            )
+            .sort((a, b) => b.lastUsedAt.localeCompare(a.lastUsedAt));
+    } catch (error) {
+        console.error('[getLocalRecentSheets] Failed:', error);
+        return [];
+    }
+}
+
+export async function rememberLocalRecentSheet(id: string, name: string): Promise<void> {
+    if (!id || !name) return;
+    try {
+        const existing = await getLocalRecentSheets();
+        const next: LocalRecentSheet[] = [
+            { id, name, lastUsedAt: new Date().toISOString() },
+            ...existing.filter((entry) => entry.id !== id),
+        ].slice(0, LOCAL_RECENT_SHEETS_MAX);
+        await chrome.storage.local.set({ [LOCAL_RECENT_SHEETS_KEY]: next });
+    } catch (error) {
+        console.error('[rememberLocalRecentSheet] Failed:', error);
+    }
+}
+
+/**
  * シートのヘッダーを確認し、不足があれば更新する
  */
 export async function ensureHeaders(spreadsheetId: string): Promise<void> {

--- a/src/sidepanel/features/project.ts
+++ b/src/sidepanel/features/project.ts
@@ -12,6 +12,8 @@ import {
     validateSpreadsheetFormat,
     createSpreadsheet,
     getRecentSpreadsheets,
+    getLocalRecentSheets,
+    rememberLocalRecentSheet,
     getReferencesWithStatus,
     getReferencesWithAllDecisions,
     getHighlightKeywords,
@@ -159,6 +161,10 @@ export async function handleConnect() {
         // 設定を保存
         await chrome.storage.local.set({ spreadsheetId: resolvedId });
 
+        // URL 入力で開いたシートは Drive API (drive.file スコープ) の最近一覧に
+        // 現れないため、ローカル recent に記録してドロップダウンへ合流させる
+        await rememberLocalRecentSheet(resolvedId, info.title);
+
         // 戻った際に URL 入力欄が残らないよう、ここで明示的にクリアしておく
         dom.spreadsheetInput.value = '';
 
@@ -174,17 +180,39 @@ export async function handleConnect() {
 
 /**
  * 最近使用したスプレッドシートをドロップダウンに読み込み
+ *
+ * Drive API の最近一覧 (drive.file スコープでアプリが「触れた」ファイルのみ)
+ * と、拡張機能側のローカル recent (URL 貼り付け経由で開いたシートを含む) を
+ * マージしてドロップダウンに表示する。
  */
 export async function loadRecentSheets() {
     _recentSheetsLoaded = false;
     try {
         dom.recentSheetsSelect.innerHTML = `<option value="">${t('project_loading')}</option>`;
 
-        const sheets = await getRecentSpreadsheets(15);
+        // Drive API とローカル recent は独立に取得（片方失敗してももう一方は使う）
+        const [driveSheets, localSheets] = await Promise.all([
+            getRecentSpreadsheets(15),
+            getLocalRecentSheets(),
+        ]);
+
+        // Drive API の並び順 (recency 降順) を優先し、未収録のローカル recent を末尾に合流
+        const merged: { id: string; name: string }[] = [];
+        const seen = new Set<string>();
+        for (const sheet of driveSheets) {
+            if (seen.has(sheet.id)) continue;
+            seen.add(sheet.id);
+            merged.push({ id: sheet.id, name: sheet.name });
+        }
+        for (const sheet of localSheets) {
+            if (seen.has(sheet.id)) continue;
+            seen.add(sheet.id);
+            merged.push({ id: sheet.id, name: sheet.name });
+        }
 
         dom.recentSheetsSelect.innerHTML = '';
 
-        if (sheets.length === 0) {
+        if (merged.length === 0) {
             const opt = document.createElement('option');
             opt.value = '';
             opt.textContent = t('project_noSheets');
@@ -199,7 +227,7 @@ export async function loadRecentSheets() {
         emptyOpt.textContent = t('project_selectSheet');
         dom.recentSheetsSelect.appendChild(emptyOpt);
 
-        for (const sheet of sheets) {
+        for (const sheet of merged) {
             const opt = document.createElement('option');
             opt.value = sheet.id;
             opt.textContent = sheet.name;
@@ -210,11 +238,36 @@ export async function loadRecentSheets() {
     } catch (error) {
         console.error('Failed to load recent sheets:', error);
 
+        // Drive API 失敗時もローカル recent だけで一覧を構築できないか試す
+        let localFallback: { id: string; name: string }[] = [];
+        try {
+            const localSheets = await getLocalRecentSheets();
+            localFallback = localSheets.map((s) => ({ id: s.id, name: s.name }));
+        } catch (localError) {
+            console.error('Failed to load local recent sheets:', localError);
+        }
+
         dom.recentSheetsSelect.innerHTML = '';
-        const opt = document.createElement('option');
-        opt.value = '';
-        opt.textContent = t('project_loadFailed');
-        dom.recentSheetsSelect.appendChild(opt);
+
+        if (localFallback.length > 0) {
+            const emptyOpt = document.createElement('option');
+            emptyOpt.value = '';
+            emptyOpt.textContent = t('project_selectSheet');
+            dom.recentSheetsSelect.appendChild(emptyOpt);
+            for (const sheet of localFallback) {
+                const opt = document.createElement('option');
+                opt.value = sheet.id;
+                opt.textContent = sheet.name;
+                dom.recentSheetsSelect.appendChild(opt);
+            }
+            // ローカル分は復元できたが Drive API は失敗しているので _recentSheetsLoaded は
+            // false のままにし、loadConfig の URL 入力欄フォールバックを有効に保つ
+        } else {
+            const opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = t('project_loadFailed');
+            dom.recentSheetsSelect.appendChild(opt);
+        }
 
         // 再認証ボタンを表示
         showStatus(t('project_sheetListFailed'), 'error');
@@ -260,6 +313,9 @@ export async function handleCreateNew() {
 
         // 設定を保存
         await chrome.storage.local.set({ spreadsheetId: newId });
+
+        // 新規作成シートはローカル recent にも記録し、戻った直後の一覧反映を保証する
+        await rememberLocalRecentSheet(newId, title);
 
         // 戻った際に URL 入力欄が残らないよう明示的にクリア
         dom.spreadsheetInput.value = '';


### PR DESCRIPTION
## 背景 / 課題
OAuth スコープが `drive.file` のため、Drive API `files.list` は「アプリが Drive Picker 経由で開いた／作成した」シートしか列挙しません。URL を貼り付けて開いたシートはこの条件を満たさず、初期画面に戻った際の最近一覧（ドロップダウン）から欠落していました。

> issue: 「urlで開いたスプレッドシートを再度、初期画面に戻るとプルダウンメニューに入っているはずなんだけど、出てこない」

## 修正方針
拡張機能側で接続／作成したシートを `chrome.storage.local` にローカル recent として保存し、ドロップダウン生成時に Drive API の結果とマージします。Drive API が失敗してもローカル分のみでフォールバック表示します。

## 変更内容
- `src/lib/sheets-api.ts`
  - `LocalRecentSheet` 型と `getLocalRecentSheets` / `rememberLocalRecentSheet` を追加（最大30件、最新優先・重複除去）
- `src/sidepanel/features/project.ts`
  - `handleConnect` 成功時に ID + タイトルをローカル recent へ記録
  - `handleCreateNew` でも新規作成シートをローカル recent へ記録
  - `loadRecentSheets` を Drive API + ローカル recent のマージ表示に変更
  - Drive API 失敗時はローカル分だけで一覧を構築するフォールバック追加

## 動作
- URL 貼り付けで開いたシートが、戻った際にドロップダウンへ登場する
- Drive API 経由のシートと URL 経由のシートが一つの一覧に統合される
- Drive API 失敗時もローカル分は残り、`drive.file` スコープ起因の欠落を救済

## 検証
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (21/21)
- `npm run dev` ビルド成功

## Test plan
- [ ] URL を貼り付けて開いたシートで戻る → ドロップダウンに表示されることを確認
- [ ] 既存の Drive Picker / 新規作成経由のシートも従来通りドロップダウンに表示されることを確認
- [ ] Drive API 認証エラー時もローカル recent 分は表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)