### PR TITLE
feat: AI判定フィルターをAIレビュアー別に独立適用 + Qwen3 Maxベンチマーク追加 (v0.20.1)

### DIFF
--- a/experiments/openrouter-bench/results/experiment_OR-Q3_2026-05-23T20-18-34.log.json
+++ b/experiments/openrouter-bench/results/experiment_OR-Q3_2026-05-23T20-18-34.log.json
@@ -19,5 +19,30 @@
       "delayBetweenRequests": 3300
     },
     "screeningPrompt": "You are a screener for a systematic review.\nSensitivity is paramount in systematic reviews to avoid missing relevant studies.\nIf you are unsure or if the full text is required to make a definitive decision, you MUST include the study.\n\n## Inclusion Criteria\nInclude studies on in vivo models of depression (Animal studies).\nExclude human studies.\nExclude studies where 'depression' refers to respiratory depression, cardiac depression, etc.\n\nInclude studies that meet the inclusion criteria.\nExclude studies that do not meet the criteria or are clearly irrelevant."
-  }
+  },
+  "results": {
+    "processedCount": 1993,
+    "successCount": 1992,
+    "failCount": 1,
+    "durationMs": 22971575,
+    "avgTimePerItem": 11526.128951329654,
+    "tokensTotal": {
+      "prompt": 1323965,
+      "completion": 268394,
+      "reasoning": 0
+    },
+    "estimatedCostUsd": 3.199122
+  },
+  "evaluation": {
+    "threshold": 0.5,
+    "truePositives": 262,
+    "falsePositives": 171,
+    "trueNegatives": 1541,
+    "falseNegatives": 18,
+    "sensitivity": 0.9357142857142857,
+    "specificity": 0.9001168224299065,
+    "precision": 0.605080831408776,
+    "fBetaScore": 0.9255988129725146
+  },
+  "endTime": "2026-05-24T02:41:26.569Z"
 }

--- a/experiments/openrouter-bench/results/items_OR-Q3_2026-05-23T20-18-34.json
+++ b/experiments/openrouter-bench/results/items_OR-Q3_2026-05-23T20-18-34.json
@@ -1,0 +1,30351 @@
+[
+  {
+    "ref_id": "Depression-SLIM-1",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない。研究対象はグルコースアナログの細胞輸送過程への影響であり、うつ病とは無関係である。"
+    ],
+    "durationMs": 3426,
+    "usage": {
+      "prompt": 807,
+      "completion": 69,
+      "reasoning": 0,
+      "total": 876
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-2",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が生殖機能の低下を指しており、うつ病モデルではない。動物実験ではあるが、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 4183,
+    "usage": {
+      "prompt": 560,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 674
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-3",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトであり、動物モデルに関する記述がない"
+    ],
+    "durationMs": 3767,
+    "usage": {
+      "prompt": 482,
+      "completion": 92,
+      "reasoning": 0,
+      "total": 574
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-4",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病モデルのin vivo研究であり、ヒト研究や呼吸・心臓の抑制とは無関係である"
+    ],
+    "durationMs": 7199,
+    "usage": {
+      "prompt": 759,
+      "completion": 208,
+      "reasoning": 0,
+      "total": 967
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-5",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能低下などの生理的抑制を指しており、うつ病（depression as a mental disorder）の動物モデルではない"
+    ],
+    "durationMs": 5818,
+    "usage": {
+      "prompt": 1033,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 1191
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-6",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性軽度ストレス（CMS）ラットモデルを用いたうつ病の動物実験であり、対象がin vivoモデルのうつ病研究である"
+    ],
+    "durationMs": 6514,
+    "usage": {
+      "prompt": 755,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 933
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-7",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性予測不能ストレス（CUS）ラットモデルを用いたうつ病の動物モデル研究であり、in vivo動物実験であることが明確"
+    ],
+    "durationMs": 7197,
+    "usage": {
+      "prompt": 688,
+      "completion": 204,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-8",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデル研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 6981,
+    "usage": {
+      "prompt": 827,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 1006
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-9",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または代謝性の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3898,
+    "usage": {
+      "prompt": 737,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 835
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-10",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく動物（犬）ではあるが、研究目的は鉛中毒による臨床症状の評価であり、うつ病（depression）のin vivoモデルを用いた研究ではない。「depression」は本抄録では全身的な抑うつ状態（中毒症状の一部）を指しており、精神疾患としてのうつ病を対象としていない。"
+    ],
+    "durationMs": 8362,
+    "usage": {
+      "prompt": 733,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-11",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制など、うつ病とは無関係な文脈で使用されている",
+      "対象が犬の心筋収縮能に関する研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 7317,
+    "usage": {
+      "prompt": 952,
+      "completion": 216,
+      "reasoning": 0,
+      "total": 1168
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-12",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトを含む研究であり、うつ病の動物モデルに関する記述がない"
+    ],
+    "durationMs": 4525,
+    "usage": {
+      "prompt": 649,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 771
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-13",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」または関連する動物モデルに関する記述がなく、片頭痛に関する研究であることが示唆されている"
+    ],
+    "durationMs": 3878,
+    "usage": {
+      "prompt": 397,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 495
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-14",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3725,
+    "usage": {
+      "prompt": 588,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 686
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-15",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は心臓の機能低下（心拍数の抑制）を指しており、うつ病モデルではない",
+      "対象はラット心臓の虚血モデルであり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 5054,
+    "usage": {
+      "prompt": 680,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 821
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-16",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や皮質拡延性抑制（CSD）など、うつ病とは無関係な文脈で使用されている可能性が高い"
+    ],
+    "durationMs": 4653,
+    "usage": {
+      "prompt": 407,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 510
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-17",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が遺伝学的用語「inbreeding depression（近交劣勢）」を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4000,
+    "usage": {
+      "prompt": 1159,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 1267
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-18",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、四肢再生に関する両生類の研究である"
+    ],
+    "durationMs": 2514,
+    "usage": {
+      "prompt": 688,
+      "completion": 49,
+      "reasoning": 0,
+      "total": 737
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-19",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅球摘出ラットを用いたうつ病の動物モデルに関する研究であり、in vivo動物実験であるため"
+    ],
+    "durationMs": 4374,
+    "usage": {
+      "prompt": 647,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 767
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-20",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、視床下部-下垂体-副腎系の機能に関する研究である"
+    ],
+    "durationMs": 6451,
+    "usage": {
+      "prompt": 518,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 700
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-21",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が酵素活性の低下（amylase activity depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5896,
+    "usage": {
+      "prompt": 704,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 869
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-22",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、発達期のGABA作動性シナプス伝達の研究である"
+    ],
+    "durationMs": 2716,
+    "usage": {
+      "prompt": 804,
+      "completion": 58,
+      "reasoning": 0,
+      "total": 862
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-23",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "抄録において「depression」がうつ病として言及されているが、実際の実験評価項目は「慢性ストレス症状」と「不安様行動」のみであり、うつ病モデルとしての評価または測定が行われていない。うつ病関連の記述は背景説明にとどまり、研究対象ではない。"
+    ],
+    "durationMs": 7142,
+    "usage": {
+      "prompt": 717,
+      "completion": 214,
+      "reasoning": 0,
+      "total": 931
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-24",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究であり、in vivo のラット実験であるため"
+    ],
+    "durationMs": 5500,
+    "usage": {
+      "prompt": 824,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 973
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-25",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2652,
+    "usage": {
+      "prompt": 409,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-26",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）に関する記述がなく、肝臓や尿中のアスコルビン酸濃度に関する研究であるため、うつ病のin vivoモデルの研究ではないと判断される"
+    ],
+    "durationMs": 3045,
+    "usage": {
+      "prompt": 419,
+      "completion": 77,
+      "reasoning": 0,
+      "total": 496
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-27",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」や動物モデルに関する記述がなく、ミトコンドリア呼吸に関する生化学的研究とみられるため"
+    ],
+    "durationMs": 3138,
+    "usage": {
+      "prompt": 408,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 467
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-28",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivo動物モデル（NETノックアウトマウス）を用いたうつ病関連研究であり、人間の研究ではない"
+    ],
+    "durationMs": 4117,
+    "usage": {
+      "prompt": 717,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 830
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-29",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する用語が含まれておらず、Ehrlich ascites tumor cells（腫瘍細胞）に関する代謝研究であり、うつ病のin vivo動物モデルの研究ではないと判断される"
+    ],
+    "durationMs": 4898,
+    "usage": {
+      "prompt": 405,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 543
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-30",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」とは気分障害としてのうつ病ではなく、鳥の活動低下を指しており、うつ病のin vivo動物モデルの研究ではない"
+    ],
+    "durationMs": 4153,
+    "usage": {
+      "prompt": 634,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 744
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-31",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした精神分析研究であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 5368,
+    "usage": {
+      "prompt": 577,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 714
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-32",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫機能の抑制（免疫抑制）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4114,
+    "usage": {
+      "prompt": 584,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 691
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-33",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がDNA合成活性の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3694,
+    "usage": {
+      "prompt": 671,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 764
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-34",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルではないため除外"
+    ],
+    "durationMs": 3852,
+    "usage": {
+      "prompt": 668,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 765
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-35",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は酵素活性の低下（代謝抑制）を指しており、うつ病モデルではない",
+      "対象が脳損傷後の酵素活性変化であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "呼吸性や心臓性の抑制ではないが、精神疾患としての「うつ病」と無関係"
+    ],
+    "durationMs": 6944,
+    "usage": {
+      "prompt": 733,
+      "completion": 201,
+      "reasoning": 0,
+      "total": 934
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-36",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした症例報告であり、動物実験ではないため"
+    ],
+    "durationMs": 4360,
+    "usage": {
+      "prompt": 589,
+      "completion": 94,
+      "reasoning": 0,
+      "total": 683
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-37",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が古生物学・霊長類の化石に関する研究であり、うつ病のin vivo動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 2564,
+    "usage": {
+      "prompt": 824,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-38",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅球摘出ラットを用いたうつ病の動物モデルに関する研究であり、明確にin vivo動物実験であるため"
+    ],
+    "durationMs": 5997,
+    "usage": {
+      "prompt": 753,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 927
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-39",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、シナプスの長期抑圧（long-term depression, LTD）を指している",
+      "対象はin vitro（試験管内）の海馬スライスであり、in vivoモデルではない"
+    ],
+    "durationMs": 6224,
+    "usage": {
+      "prompt": 785,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 959
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-40",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」が運動性の抑制（locomotionのdepression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3737,
+    "usage": {
+      "prompt": 572,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 667
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-41",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸器抑制や循環抑制など、うつ病とは無関係な文脈で使用されており、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4342,
+    "usage": {
+      "prompt": 790,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 908
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-42",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や代謝抑制などうつ病以外の文脈で使用されており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4217,
+    "usage": {
+      "prompt": 855,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 968
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-43",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がパーキンソン病におけるL-DOPA誘発性ジスキネジアであり、うつ病の動物モデルではない",
+      "抄録中に「depression」という語が現れるが、これは長期抑圧（long-term depression: LTD）という神経可塑性の用語であり、うつ病を意味しない"
+    ],
+    "durationMs": 5832,
+    "usage": {
+      "prompt": 682,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 849
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-44",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、海馬のシナプス可塑性に関する神経生理学的研究である"
+    ],
+    "durationMs": 4040,
+    "usage": {
+      "prompt": 716,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-45",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "抄録にうつ病や動物モデルに関する記述が全くない"
+    ],
+    "durationMs": 2524,
+    "usage": {
+      "prompt": 506,
+      "completion": 56,
+      "reasoning": 0,
+      "total": 562
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-46",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が神経生理学的な応答の減衰（例：EPSP depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない。また、対象はザリガニであり、うつ病のin vivoモデルとは無関係。"
+    ],
+    "durationMs": 6287,
+    "usage": {
+      "prompt": 763,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 948
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-47",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来細胞株（SHSY5Y）を用いたin vitro研究であり、in vivo動物モデルではない"
+    ],
+    "durationMs": 4883,
+    "usage": {
+      "prompt": 722,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-48",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が栄養欠乏による免疫反応の抑制を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4579,
+    "usage": {
+      "prompt": 496,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 614
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-49",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸・循環系の機能低下（心筋抑制）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4673,
+    "usage": {
+      "prompt": 842,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 945
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-50",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした薬理学的レビューであり、in vivo動物モデルの研究ではない"
+    ],
+    "durationMs": 4546,
+    "usage": {
+      "prompt": 613,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 737
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-51",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、神経生理学的抑制（depressant effects）を指しており、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6796,
+    "usage": {
+      "prompt": 1050,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 1247
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-52",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、行動の抑制（self-stimulation behaviourの低下）を指しており、うつ病のin vivoモデルの研究ではない"
+    ],
+    "durationMs": 4606,
+    "usage": {
+      "prompt": 529,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 649
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-53",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究であり、ストレス関連障害（うつ病を含む）の神経機構を検討しているため"
+    ],
+    "durationMs": 5766,
+    "usage": {
+      "prompt": 788,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 955
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-54",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトル中の「DEPRESSION」は抑うつを指している可能性が低く、免疫反応の抑制などを意味している可能性が高い",
+      "ヒナ（chicks）を用いたin vivo研究ではあるが、対象が「抑うつ病」のモデルとは明確に記載されていない",
+      "抄録がなく、抑うつ行動モデルであるかどうかを判断する情報が不足しているため、除外が適切と判断されるが、感度を考慮してわずかな包含確率を付与"
+    ],
+    "durationMs": 6314,
+    "usage": {
+      "prompt": 418,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 600
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-55",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や血圧低下（baropressure reflexなど）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 6310,
+    "usage": {
+      "prompt": 612,
+      "completion": 180,
+      "reasoning": 0,
+      "total": 792
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-56",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制など精神疾患としてのうつ病を指していない",
+      "研究は心血管系への影響を評価しており、うつ病モデルではない"
+    ],
+    "durationMs": 4503,
+    "usage": {
+      "prompt": 804,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 927
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-57",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2294,
+    "usage": {
+      "prompt": 417,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 468
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-58",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や代謝抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3496,
+    "usage": {
+      "prompt": 853,
+      "completion": 89,
+      "reasoning": 0,
+      "total": 942
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-59",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が薬物代謝の抑制を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5651,
+    "usage": {
+      "prompt": 655,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 814
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-60",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、脂質過酸化に関する生化学的研究である"
+    ],
+    "durationMs": 5712,
+    "usage": {
+      "prompt": 585,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 731
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-61",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、腸管からのグルコース吸収を調べた研究である"
+    ],
+    "durationMs": 4337,
+    "usage": {
+      "prompt": 412,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 521
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-62",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、GABAレベルと運動行動の関係に焦点を当てている"
+    ],
+    "durationMs": 4125,
+    "usage": {
+      "prompt": 471,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 576
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-63",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから人間を対象とした健康・脳機能に関する記事であると判断され、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 4134,
+    "usage": {
+      "prompt": 408,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-64",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などではなくうつ病を指しているか不明だが、本研究はカエルの運動神経終末における神経伝達物質放出の抑制（e.p.p. depression）に関するものであり、うつ病のin vivo動物モデルではない。"
+    ],
+    "durationMs": 5561,
+    "usage": {
+      "prompt": 710,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 862
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-65",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性軽度ストレス（CMS）ラットを用いたうつ病モデルに関する動物実験であり、in vivoモデルとして明確に記載されている"
+    ],
+    "durationMs": 5847,
+    "usage": {
+      "prompt": 597,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 765
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-66",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指しており、うつ病モデルではない",
+      "動物を用いたうつ病のin vivoモデルに関する記述が全くない"
+    ],
+    "durationMs": 5248,
+    "usage": {
+      "prompt": 704,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 829
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-67",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression）を指している可能性が高い",
+      "動物実験かどうか不明だが、タイトルからうつ病モデルの研究とは考えにくい"
+    ],
+    "durationMs": 4363,
+    "usage": {
+      "prompt": 402,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 518
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-68",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（うつ病患者および健常対照）であり、動物モデルではないため"
+    ],
+    "durationMs": 6463,
+    "usage": {
+      "prompt": 776,
+      "completion": 184,
+      "reasoning": 0,
+      "total": 960
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-69",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "社会的隔離はうつ病の動物モデルとして広く用いられており、本研究は成体マウスを用いたin vivoモデルである"
+    ],
+    "durationMs": 6013,
+    "usage": {
+      "prompt": 738,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 910
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-70",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（FSLラットおよびFHラット）を用いた研究であり、ヒト研究ではない。うつ病は呼吸抑制や心機能抑制ではなく精神疾患として扱われている。"
+    ],
+    "durationMs": 6513,
+    "usage": {
+      "prompt": 769,
+      "completion": 192,
+      "reasoning": 0,
+      "total": 961
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-71",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした災害事例報告であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4485,
+    "usage": {
+      "prompt": 740,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-72",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、前庭眼反射に関する研究である"
+    ],
+    "durationMs": 4269,
+    "usage": {
+      "prompt": 770,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 867
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-73",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は感覚活動の抑制（鎮痛作用）を指しており、うつ病モデルではない",
+      "対象はラットだが、うつ病のin vivoモデルではなく疼痛関連の神経生理学的研究"
+    ],
+    "durationMs": 6884,
+    "usage": {
+      "prompt": 808,
+      "completion": 198,
+      "reasoning": 0,
+      "total": 1006
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-74",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなく、in vitroのラット海馬スライスを用いた実験であるため"
+    ],
+    "durationMs": 3843,
+    "usage": {
+      "prompt": 842,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 946
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-75",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 5279,
+    "usage": {
+      "prompt": 1029,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 1167
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-76",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋収縮の抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4234,
+    "usage": {
+      "prompt": 762,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 872
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-77",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、長期抑圧（long-term depression, LTD）を指しているが、これは神経科学におけるシナプス可塑性の現象であり、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 6412,
+    "usage": {
+      "prompt": 649,
+      "completion": 184,
+      "reasoning": 0,
+      "total": 833
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-78",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4440,
+    "usage": {
+      "prompt": 563,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 684
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-79",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ラット精巣におけるテストステロン生合成の調節に関する研究である"
+    ],
+    "durationMs": 4194,
+    "usage": {
+      "prompt": 412,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 524
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-80",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、鶏胚心臓のコリン作動性反応に関する研究である"
+    ],
+    "durationMs": 4528,
+    "usage": {
+      "prompt": 418,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 539
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-81",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「rat brain」とあるため動物実験の可能性があるが、うつ病モデルかどうかは不明であり、抄録がないため判断できない"
+    ],
+    "durationMs": 5234,
+    "usage": {
+      "prompt": 413,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 514
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-82",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病関連のin vivo研究であり、ヒト研究や呼吸・心臓の抑制を意味する「depression」ではない"
+    ],
+    "durationMs": 6987,
+    "usage": {
+      "prompt": 901,
+      "completion": 193,
+      "reasoning": 0,
+      "total": 1094
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-83",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は免疫機能の低下（phagocytic activityのdepression）を指しており、うつ病（depression）の動物モデルではない",
+      "対象は閉塞性黄疸に伴う免疫抑制であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 5861,
+    "usage": {
+      "prompt": 736,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 907
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-84",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸・循環・消化などの生理的抑制（繊維消化率の低下）を指しており、うつ病モデルではない",
+      "対象はウシでありうつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 4519,
+    "usage": {
+      "prompt": 616,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 741
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-85",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depresses」や「depression」は神経活動の抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない",
+      "対象は脊髄切断猫であり、うつ病の行動学的または病理学的モデルではない",
+      "呼吸抑制や心機能抑制と同様に、本論文の「depression」は生理学的な抑制現象を指す"
+    ],
+    "durationMs": 7025,
+    "usage": {
+      "prompt": 615,
+      "completion": 207,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-86",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋収縮の抑制（cardiac depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4643,
+    "usage": {
+      "prompt": 918,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 1038
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-87",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が精神疾患としてのうつ病ではなく、一般的な抑うつ状態（元気消失）を指しており、うつ病のin vivoモデルの研究ではない",
+      "対象は猫の産科救急症例であり、うつ病の動物モデル研究ではない",
+      "ヒトを対象とした研究ではないが、うつ病モデルの研究でもないため除外"
+    ],
+    "durationMs": 5698,
+    "usage": {
+      "prompt": 506,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 666
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-88",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫反応の抑制を指しており、うつ病（depression）の動物モデルではない",
+      "対象がうつ病ではなく免疫調節に関する研究"
+    ],
+    "durationMs": 4186,
+    "usage": {
+      "prompt": 682,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 796
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-89",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 2947,
+    "usage": {
+      "prompt": 414,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 471
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-90",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や生理機能の抑制を指しており、うつ病モデルではない",
+      "うつ病に関する動物モデルの研究ではない"
+    ],
+    "durationMs": 5446,
+    "usage": {
+      "prompt": 666,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-91",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、側坐核損傷ラットの浸透圧応答に関する研究である"
+    ],
+    "durationMs": 6352,
+    "usage": {
+      "prompt": 578,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 760
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-92",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動のin vivoモデルに関する動物研究であり、対象とするうつ病が精神疾患としてのうつ病であることが明確である"
+    ],
+    "durationMs": 6057,
+    "usage": {
+      "prompt": 667,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 843
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-93",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関するin vivo動物実験であり、ヒト研究や呼吸・心臓の抑制とは無関係である"
+    ],
+    "durationMs": 7185,
+    "usage": {
+      "prompt": 803,
+      "completion": 215,
+      "reasoning": 0,
+      "total": 1018
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-94",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または代謝性アシドーシスに伴う血液pHの低下を指しており、うつ病モデルではない",
+      "対象がニジマス（魚）であるが、うつ病のin vivoモデルではなく、代謝性アシドーシスの腎臓応答を調べた研究"
+    ],
+    "durationMs": 5310,
+    "usage": {
+      "prompt": 658,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 807
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-95",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される",
+      "「pulmonary」および「prostaglandin metabolism」から、呼吸器系または代謝に関する研究であり、精神疾患のうつ病とは無関係と推定される"
+    ],
+    "durationMs": 5856,
+    "usage": {
+      "prompt": 419,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 578
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-96",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5666,
+    "usage": {
+      "prompt": 1023,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 1181
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-97",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が攻撃行動であり、うつ病モデルではない"
+    ],
+    "durationMs": 4706,
+    "usage": {
+      "prompt": 625,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 753
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-98",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が「inbreeding depression（近交劣勢）」を指しており、これはうつ病モデルではなく遺伝的適応度の低下を意味するため、対象外である。",
+      "研究はショウジョウバエを用いた生殖行動に関するものであり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 5587,
+    "usage": {
+      "prompt": 700,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 856
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-99",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓機能の抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4263,
+    "usage": {
+      "prompt": 795,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 910
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-100",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病関連の神経機構に関するin vivo動物研究であり、対象がヒトではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 6333,
+    "usage": {
+      "prompt": 805,
+      "completion": 184,
+      "reasoning": 0,
+      "total": 989
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-101",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が麻酔下の犬であり、うつ病のin vivoモデルに関する研究ではない。また、「depression」がうつ病を指していない。"
+    ],
+    "durationMs": 4353,
+    "usage": {
+      "prompt": 696,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 803
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-102",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたin vivoうつ病モデル（レセルピン誘発うつ）に関する動物実験であり、対象とする研究である"
+    ],
+    "durationMs": 4088,
+    "usage": {
+      "prompt": 432,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 541
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-103",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「inbreeding depression（近交劣勢）」を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4027,
+    "usage": {
+      "prompt": 818,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 920
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-104",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivo実験で、うつ病様行動（sucrose preferenceの低下など）を評価しており、うつ病の動物モデル研究に該当する"
+    ],
+    "durationMs": 4318,
+    "usage": {
+      "prompt": 653,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 769
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-105",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルを対象とした研究であり、抗うつ薬様効果が報告されている"
+    ],
+    "durationMs": 3953,
+    "usage": {
+      "prompt": 727,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 835
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-106",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルを対象とした研究ではなく、学習・記憶に関連する神経可塑性の研究である"
+    ],
+    "durationMs": 4023,
+    "usage": {
+      "prompt": 711,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 817
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-107",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivoモデル（脳スライスを含む）に関する研究であり、うつ病に関連するセロトニン神経の機能を検討している。ヒト研究ではなく、呼吸性・心臓性の「depression」ではない。"
+    ],
+    "durationMs": 5914,
+    "usage": {
+      "prompt": 917,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 1091
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-108",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 4057,
+    "usage": {
+      "prompt": 405,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 458
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-109",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が筋収縮の抑制（baseline twitch tensionの低下）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 3886,
+    "usage": {
+      "prompt": 765,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 871
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-110",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の動物モデルを示す記述がなく、抄録が存在しないため、対象となる研究かどうか判断できないが、タイトルから推測される内容（リゼルグ酸アナログ、5-フェニルニコチンアミド、ナイペコタミド）はうつ病のin vivoモデル研究とは明らかに関連がない"
+    ],
+    "durationMs": 4539,
+    "usage": {
+      "prompt": 412,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 527
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-111",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、抑うつモデルの使用が明確でないが、恐怖条件付けとドパミンに関する動物実験の可能性があるため、フルテキスト確認が必要"
+    ],
+    "durationMs": 3985,
+    "usage": {
+      "prompt": 417,
+      "completion": 78,
+      "reasoning": 0,
+      "total": 495
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-112",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病関連行動の動物モデルに関する研究であり、in vivo のうつ病モデルに該当する"
+    ],
+    "durationMs": 6365,
+    "usage": {
+      "prompt": 677,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 847
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-113",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や代謝抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3951,
+    "usage": {
+      "prompt": 555,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 656
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-114",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "抄録に「in vivo」動物モデルを用いたうつ病関連の神経生理学的実験が記載されており、ヒト研究や呼吸・心臓の抑制とは無関係である"
+    ],
+    "durationMs": 6043,
+    "usage": {
+      "prompt": 727,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 881
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-115",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象が心臓の電気生理学的変化であり、うつ病（depression）の動物モデルではない。文中の'depression'は心筋細胞の電流の抑制（depressed current）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5773,
+    "usage": {
+      "prompt": 765,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 933
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-116",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病関連の行動試験（強制水泳試験）を実施しており、in vivo動物モデルの研究であるため"
+    ],
+    "durationMs": 5215,
+    "usage": {
+      "prompt": 772,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-117",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は血圧の低下（depressor reaction）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3870,
+    "usage": {
+      "prompt": 590,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 695
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-118",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動のin vivoモデルに関する動物研究であり、対象とするうつ病が呼吸抑制や心機能抑制などの非精神医学的用法ではない"
+    ],
+    "durationMs": 6581,
+    "usage": {
+      "prompt": 648,
+      "completion": 184,
+      "reasoning": 0,
+      "total": 832
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-119",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病の動物モデルではなく、心筋収縮の抑制メカニズムに関するものである",
+      "「depression」が心機能の抑制（cardiac depression）を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 7121,
+    "usage": {
+      "prompt": 998,
+      "completion": 212,
+      "reasoning": 0,
+      "total": 1210
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-120",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルではなく、てんかんおよび拡張性抑制に関するin vitro研究である"
+    ],
+    "durationMs": 7065,
+    "usage": {
+      "prompt": 1061,
+      "completion": 205,
+      "reasoning": 0,
+      "total": 1266
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-121",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性コルチコステロン処理によるうつ病様行動を評価したin vivo動物実験であり、うつ病モデルとして関連性が高い"
+    ],
+    "durationMs": 8419,
+    "usage": {
+      "prompt": 745,
+      "completion": 242,
+      "reasoning": 0,
+      "total": 987
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-122",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルではなく、てんかん活動の研究である"
+    ],
+    "durationMs": 4995,
+    "usage": {
+      "prompt": 763,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 898
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-123",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "条件付き敗北はうつ病の動物モデルとして広く用いられており、本研究はハムスターを用いたin vivo実験であるため、対象となる。"
+    ],
+    "durationMs": 7034,
+    "usage": {
+      "prompt": 699,
+      "completion": 205,
+      "reasoning": 0,
+      "total": 904
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-124",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、シナプス可塑性の一種である長期抑圧（LTD: long-term depression）を指しており、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5575,
+    "usage": {
+      "prompt": 625,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 750
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-125",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット脳由来の酵素（in vitro）であり、うつ病のin vivo動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 3938,
+    "usage": {
+      "prompt": 681,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 789
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-126",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能抑制などの文脈ではなく、本研究では「somatostatin releaseの抑制」を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 4570,
+    "usage": {
+      "prompt": 1011,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 1132
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-127",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3934,
+    "usage": {
+      "prompt": 401,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 498
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-128",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、ミトコンドリアクレアチンキナーゼの構造解析に関する生化学的研究である"
+    ],
+    "durationMs": 2724,
+    "usage": {
+      "prompt": 737,
+      "completion": 63,
+      "reasoning": 0,
+      "total": 800
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-129",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「cardiodepressant」や「contractile performance」など心臓の抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない",
+      "対象はウサギではなくギニアピッグの心臓であり、うつ病の行動や神経生物学的評価ではない"
+    ],
+    "durationMs": 6804,
+    "usage": {
+      "prompt": 717,
+      "completion": 200,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-130",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトの疾患（感情障害）に関する考察であり、うつ病のin vivo動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 4963,
+    "usage": {
+      "prompt": 658,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 790
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-131",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ヒスチジン血症の代謝研究である"
+    ],
+    "durationMs": 3985,
+    "usage": {
+      "prompt": 722,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 829
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-132",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression）を指しており、呼吸性または心臓性の抑制とは異なるが、精神疾患としてのうつ病の動物モデルではない"
+    ],
+    "durationMs": 6240,
+    "usage": {
+      "prompt": 542,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 710
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-133",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経生理学的な反射抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4189,
+    "usage": {
+      "prompt": 719,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 825
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-134",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が神経生理学的抑制（皮質反応の抑制）を指しており、うつ病モデルではない",
+      "うつ病（depression）の動物モデルに関する記述が一切ない",
+      "対象がてんかんモデル（けいれん）と神経生理学的反応であり、精神疾患モデルではない"
+    ],
+    "durationMs": 6212,
+    "usage": {
+      "prompt": 600,
+      "completion": 173,
+      "reasoning": 0,
+      "total": 773
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-135",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病のin vivoモデル（行動絶望泳ぎ試験）に関する動物研究であり、対象とするうつ病は精神疾患としてのうつ病である"
+    ],
+    "durationMs": 5452,
+    "usage": {
+      "prompt": 579,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 736
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-136",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、心筋梗塞の動物モデルである",
+      "「depression」という語はこの文献では「CPK depression（CPK活性の低下）」という生理学的抑制を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 6297,
+    "usage": {
+      "prompt": 1120,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 1302
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-137",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3392,
+    "usage": {
+      "prompt": 793,
+      "completion": 86,
+      "reasoning": 0,
+      "total": 879
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-138",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「spreading depression」は神経生理学的現象であり、うつ病（depression）の動物モデルではない",
+      "呼吸性または心臓性のdepressionではなく、脳内の拡延性抑制を指しているが、これは精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 4692,
+    "usage": {
+      "prompt": 412,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 544
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-139",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性や心臓性の抑制ではなくうつ病を指しているか確認できないが、本研究は精液中のアルカリホスファターゼの機能に関する動物（雄豚）の生殖研究であり、うつ病のin vivoモデルではない。",
+      "「depression of the capacitating process」は生理的抑制を意味しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6535,
+    "usage": {
+      "prompt": 830,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 1008
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-140",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（癌患者）であり、動物モデルではないため除外"
+    ],
+    "durationMs": 4740,
+    "usage": {
+      "prompt": 689,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 808
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-141",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（ラット）を用いた研究であり、対象が明確に動物実験であるため"
+    ],
+    "durationMs": 5007,
+    "usage": {
+      "prompt": 569,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 697
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-142",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は筋収縮力の低下を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5448,
+    "usage": {
+      "prompt": 773,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 919
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-143",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」が脳内のニコチンアミドアデニンジヌクレオチドの減少を指しており、うつ病モデルではなく生化学的抑制を意味している可能性が高い",
+      "動物実験かどうか不明だが、タイトルからうつ病のin vivoモデルとは判断できない",
+      "呼吸抑制や心機能抑制などと同様に、ここでの「depression」は生理機能の抑制を指していると推測される"
+    ],
+    "durationMs": 6006,
+    "usage": {
+      "prompt": 417,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 593
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-144",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2369,
+    "usage": {
+      "prompt": 414,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 469
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-145",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたin vivo動物実験であり、うつ病モデルに関連する恐怖条件付けストレス下での海馬可塑性を評価している"
+    ],
+    "durationMs": 5321,
+    "usage": {
+      "prompt": 743,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 886
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-146",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などの文脈ではなく、カスパーゼL活性の「抑制（suppression）」を指しているが、本研究はin vivo動物モデルではなく、培養海馬スライス（in vitro）を用いた実験であるため、対象外となる"
+    ],
+    "durationMs": 5172,
+    "usage": {
+      "prompt": 660,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 801
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-147",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなく、脳スライスを用いたex vivo（in vitro）実験であるため",
+      "うつ病（depression）ではなく虚血後の脱分極（depolarization）を指しており、呼吸性うつや心機能低下とも無関係だが、精神疾患としてのうつ病の研究ではないため"
+    ],
+    "durationMs": 6857,
+    "usage": {
+      "prompt": 792,
+      "completion": 199,
+      "reasoning": 0,
+      "total": 991
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-148",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4687,
+    "usage": {
+      "prompt": 891,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 1005
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-149",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がサル（ヒト以外の霊長類）であるが、うつ病モデルに関する記述がタイトルにも抄録にも含まれておらず、研究内容が脳の自己刺激および血圧に焦点を当てており、うつ病のin vivoモデルとは関連が不明である"
+    ],
+    "durationMs": 4917,
+    "usage": {
+      "prompt": 407,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 544
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-150",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "Flinders sensitive line (FSL) ラットを用いたうつ病の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 6062,
+    "usage": {
+      "prompt": 645,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 810
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-151",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が体重増加の抑制（body weight gain の低下）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4328,
+    "usage": {
+      "prompt": 828,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 933
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-152",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「CNS depressant activity」は中枢神経抑制作用を指しており、うつ病（depression）の動物モデルに関する研究ではない。うつ病モデルの評価方法（例：強制水泳試験、尾吊り試験など）が記載されていない。"
+    ],
+    "durationMs": 6854,
+    "usage": {
+      "prompt": 783,
+      "completion": 196,
+      "reasoning": 0,
+      "total": 979
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-153",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから、in vitroのリンパ球刺激に関する研究であり、うつ病のin vivo動物モデルの研究ではないことが明確である"
+    ],
+    "durationMs": 4927,
+    "usage": {
+      "prompt": 408,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 522
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-154",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression, CSD）を指しており、呼吸抑制や心機能抑制と同様に精神疾患としてのうつ病とは無関係である"
+    ],
+    "durationMs": 5993,
+    "usage": {
+      "prompt": 783,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 953
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-155",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、がん浸潤に関するin vitro研究であるため、うつ病のin vivo動物モデルの研究ではない"
+    ],
+    "durationMs": 4152,
+    "usage": {
+      "prompt": 401,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 513
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-156",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "抄録に「Animals treated with this testing compound」とあるが、うつ病のin vivoモデルを使用しているかどうかは明記されておらず、全文確認が必要"
+    ],
+    "durationMs": 4485,
+    "usage": {
+      "prompt": 770,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 894
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-157",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経筋接合部電流の抑制を指しており、うつ病（depression）の動物モデルではない",
+      "対象はカエルの神経筋接合部であり、うつ病のin vivoモデルではない",
+      "呼吸抑制や受容体機能の抑制など、うつ病とは無関係な「depression」の用法"
+    ],
+    "durationMs": 6087,
+    "usage": {
+      "prompt": 620,
+      "completion": 173,
+      "reasoning": 0,
+      "total": 793
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-158",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、性腺刺激ホルモンの分泌に関する研究である"
+    ],
+    "durationMs": 4560,
+    "usage": {
+      "prompt": 656,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 785
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-159",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "うつ病の動物モデルに関する研究であるという明確な根拠がタイトルに含まれていない。ネオナタル期のNGF処置によるノルエピネフリン含量の変化を調べているが、うつ病との関連は示されていない。"
+    ],
+    "durationMs": 5207,
+    "usage": {
+      "prompt": 413,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 561
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-160",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく動物（犬）であるが、研究テーマが循環ショックによる心臓機能低下（心臓の「depression」）であり、精神疾患としてのうつ病（depression）とは無関係である"
+    ],
+    "durationMs": 4873,
+    "usage": {
+      "prompt": 665,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 794
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-161",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」や動物モデルに関する記述が全く含まれていない"
+    ],
+    "durationMs": 2055,
+    "usage": {
+      "prompt": 402,
+      "completion": 46,
+      "reasoning": 0,
+      "total": 448
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-162",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、脳虚血後の行動変化を評価した研究であり、「うつ病」は観察されなかったと明記されている"
+    ],
+    "durationMs": 4320,
+    "usage": {
+      "prompt": 681,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 793
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-163",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく近親交配による適応度低下（inbreeding depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4116,
+    "usage": {
+      "prompt": 578,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 683
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-164",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いた強制泳ぐ試験（FST）および尾吊り試験（TST）を実施しており、うつ病のin vivo動物モデル研究である"
+    ],
+    "durationMs": 6160,
+    "usage": {
+      "prompt": 840,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 975
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-165",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する動物実験であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 6274,
+    "usage": {
+      "prompt": 821,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 1003
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-166",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトのうつ病患者を対象とした臨床研究であり、in vivo動物モデルの研究ではない"
+    ],
+    "durationMs": 4621,
+    "usage": {
+      "prompt": 762,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 889
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-167",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「in vivoモデル（ラット）」および「行動絶望テスト」といううつ病動物モデルが明記されており、対象が動物実験であることが明確"
+    ],
+    "durationMs": 5166,
+    "usage": {
+      "prompt": 413,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 531
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-168",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ラット前立腺に対するプロラクチンの影響を調べた研究である"
+    ],
+    "durationMs": 4121,
+    "usage": {
+      "prompt": 830,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 940
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-169",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢抑制（central depressant effect）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4790,
+    "usage": {
+      "prompt": 797,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 932
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-170",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が猫を用いた神経生理学的研究であり、うつ病のin vivoモデルではない。文中の'depression'は高頻度刺激時のシナプス抑制（生理学的用語）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 6484,
+    "usage": {
+      "prompt": 773,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 955
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-171",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（自殺企図患者）であり、動物モデルを使用していないため"
+    ],
+    "durationMs": 4148,
+    "usage": {
+      "prompt": 742,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 854
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-172",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が長期抑圧（long-term synaptic depression, LTD）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4063,
+    "usage": {
+      "prompt": 854,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 961
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-173",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関する動物実験が含まれており、対象とするin vivoモデルのうつ病研究に該当する"
+    ],
+    "durationMs": 6005,
+    "usage": {
+      "prompt": 732,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 896
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-174",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "in vitro実験（ウサギ脳シナプトソーム画分）であり、in vivoうつ病モデルではない"
+    ],
+    "durationMs": 4782,
+    "usage": {
+      "prompt": 653,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 784
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-175",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や循環器などの機能低下を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3928,
+    "usage": {
+      "prompt": 608,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 718
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-176",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経活動の抑制（depressant effects）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4907,
+    "usage": {
+      "prompt": 623,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 728
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-177",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒツジであり、うつ病の動物モデルではなく、肝性光過敏症に関する研究である。また、「depression」は抑うつ症状ではなく、一般的な抑うつな状態（元気消失）を指している可能性があるが、うつ病モデルではない。"
+    ],
+    "durationMs": 6405,
+    "usage": {
+      "prompt": 730,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 881
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-178",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は長期抑圧（LTD: long-term depression）を指しており、うつ病（depression）ではない",
+      "対象は小脳プルキンエ細胞のシナプス可塑性に関する動物実験だが、うつ病モデルではない"
+    ],
+    "durationMs": 5541,
+    "usage": {
+      "prompt": 648,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 799
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-179",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は酵素活性の低下を指しており、うつ病モデルの動物研究ではない",
+      "研究対象はマウスのメラノーマであり、うつ病とは無関係"
+    ],
+    "durationMs": 5795,
+    "usage": {
+      "prompt": 912,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 1079
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-180",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が野生のコガラ（鳥類）の交配行動に関する研究であり、うつ病のin vivoモデルを用いた動物実験ではない"
+    ],
+    "durationMs": 4584,
+    "usage": {
+      "prompt": 688,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 809
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-181",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、ヒトまたはin vitro神経細胞を用いたオピオイドとイオンチャネルのメカニズムに関する研究である"
+    ],
+    "durationMs": 4768,
+    "usage": {
+      "prompt": 517,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 649
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-182",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「spreading depression（拡張性抑制）」は神経生理学的現象であり、うつ病（depression）とは無関係である。研究は動物由来の臓器培養（in vitro）を使用しており、in vivoモデルではない。"
+    ],
+    "durationMs": 5580,
+    "usage": {
+      "prompt": 704,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 864
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-183",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はシナプスの短期抑制（synaptic depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4068,
+    "usage": {
+      "prompt": 544,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 653
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-184",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoマウスモデル（C57Bl10野生型およびPrPcノックアウトマウス）を用いてうつ病関連のモノアミン作動系を調査している"
+    ],
+    "durationMs": 5631,
+    "usage": {
+      "prompt": 1005,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 1157
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-185",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、マクロファージコロニースティミュレーティング因子（M-CSF）のサイトカイン産生抑制効果を調べた免疫学的研究である"
+    ],
+    "durationMs": 3382,
+    "usage": {
+      "prompt": 825,
+      "completion": 77,
+      "reasoning": 0,
+      "total": 902
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-186",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の動物モデルに関する記述がなく、抄録が存在しないため、関連性を判断できない"
+    ],
+    "durationMs": 3257,
+    "usage": {
+      "prompt": 395,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 460
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-187",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoうつ病モデルではなく、培養視床下部ニューロンを用いたin vitro実験である",
+      "うつ病に関する記述が一切含まれていない"
+    ],
+    "durationMs": 3008,
+    "usage": {
+      "prompt": 1307,
+      "completion": 72,
+      "reasoning": 0,
+      "total": 1379
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-188",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経可塑性における長期抑圧（long-term depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5467,
+    "usage": {
+      "prompt": 646,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 801
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-189",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 4166,
+    "usage": {
+      "prompt": 581,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 683
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-190",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能低下などの意味ではなく、羊毛成長の抑制（wool growth depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5022,
+    "usage": {
+      "prompt": 876,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 1013
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-191",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病を指しておらず、頭部外傷による「cortical depression（皮質陥凹）」を意味している",
+      "うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4696,
+    "usage": {
+      "prompt": 795,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 922
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-192",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来の細胞株（MEG-01および血小板）を用いたin vitro研究であり、in vivo動物モデルではない",
+      "うつ病患者のデータに言及しているが、これはヒト研究に該当する"
+    ],
+    "durationMs": 6499,
+    "usage": {
+      "prompt": 942,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 1128
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-193",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が腫瘍治療に関する動物実験であり、うつ病のin vivoモデルを含んでいない"
+    ],
+    "durationMs": 4117,
+    "usage": {
+      "prompt": 735,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 841
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-194",
+    "label_included": 0,
+    "include_probability": 0.2,
+    "reasons": [
+      "「depression」がsickness behaviorの症状の一つとして言及されているが、うつ病の動物モデルではなく、炎症性疾患に起因する一過性の症状を指している可能性が高い。うつ病のin vivoモデルに関する研究ではないと判断される。"
+    ],
+    "durationMs": 6858,
+    "usage": {
+      "prompt": 774,
+      "completion": 173,
+      "reasoning": 0,
+      "total": 947
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-195",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が犬であり動物研究ではあるが、うつ病（depression）の研究ではなく、血漿タンパク質およびアルブミン濃度に関する研究である"
+    ],
+    "durationMs": 4706,
+    "usage": {
+      "prompt": 483,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 605
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-196",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット由来の蝸牛臓器培養であり、in vivoモデルではない",
+      "「depression」は精神疾患としてのうつ病ではなく、メフロキンの神経副作用として言及されているが、研究自体は聴覚細胞の変性に焦点を当てており、うつ病モデルではない"
+    ],
+    "durationMs": 7130,
+    "usage": {
+      "prompt": 728,
+      "completion": 214,
+      "reasoning": 0,
+      "total": 942
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-197",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4708,
+    "usage": {
+      "prompt": 608,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 736
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-198",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく動物であるが、うつ病（depression）の研究ではなく、呼吸抑制（respiratory depression）に関する記述であり、精神疾患としてのうつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5277,
+    "usage": {
+      "prompt": 778,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 899
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-199",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が遅発型過敏反応の抑制を指しており、うつ病モデルではない",
+      "対象は免疫抑制作用の評価であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4712,
+    "usage": {
+      "prompt": 589,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 716
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-200",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が鶏の顆粒膜細胞を用いたin vitro研究であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 4111,
+    "usage": {
+      "prompt": 769,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 877
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-201",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病治療に関する臨床研究であり、動物モデルを用いたin vivo研究ではない"
+    ],
+    "durationMs": 5633,
+    "usage": {
+      "prompt": 660,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 818
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-202",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が線虫の新種記載であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 2400,
+    "usage": {
+      "prompt": 644,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 697
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-203",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性アシドーシスによる心筋抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4409,
+    "usage": {
+      "prompt": 826,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 943
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-204",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する記述がなく、研究対象が神経生理学的メカニズムに限定されている"
+    ],
+    "durationMs": 3104,
+    "usage": {
+      "prompt": 569,
+      "completion": 62,
+      "reasoning": 0,
+      "total": 631
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-205",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的・シナプス伝達における抑制（例: EPSCsのdepression）を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病（depression）のin vivoモデルに関する研究ではない",
+      "呼吸抑制や心機能抑制ではなく、シナプス応答の短期抑制（depression）を記述しているが、これは精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 7876,
+    "usage": {
+      "prompt": 829,
+      "completion": 238,
+      "reasoning": 0,
+      "total": 1067
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-206",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、アルコール摂取行動を対象とした動物実験である"
+    ],
+    "durationMs": 5550,
+    "usage": {
+      "prompt": 951,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 1110
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-207",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物（ゼブラフィンチ）ではあるが、うつ病（depression）の研究ではなく、成長抑制（growth depression）に関する研究であるため除外"
+    ],
+    "durationMs": 4150,
+    "usage": {
+      "prompt": 611,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 719
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-208",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（強制水泳試験、慢性軽度ストレス試験）を含む動物実験であり、うつ病に対する抗うつ作用を評価している"
+    ],
+    "durationMs": 7774,
+    "usage": {
+      "prompt": 794,
+      "completion": 227,
+      "reasoning": 0,
+      "total": 1021
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-209",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は免疫機能の抑制（lymphocyte cytotoxic activity や cytokine production の低下）を指しており、うつ病（depression as a psychiatric disorder）ではない。対象はマウスだが、うつ病モデルではない。"
+    ],
+    "durationMs": 6927,
+    "usage": {
+      "prompt": 660,
+      "completion": 206,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-210",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデル（慢性予測不能ストレス）に関するin vivo動物研究であり、対象がヒトでなく、呼吸・循環器系のdepressionではない"
+    ],
+    "durationMs": 5395,
+    "usage": {
+      "prompt": 777,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 912
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-211",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は免疫応答の抑制（cytotoxic antibody responsesの低下）を指しており、うつ病モデルではない",
+      "対象はラットであるが、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4718,
+    "usage": {
+      "prompt": 575,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 701
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-212",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や循環抑制など精神疾患としてのうつ病を指していない",
+      "研究対象は胎児羊であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 7485,
+    "usage": {
+      "prompt": 781,
+      "completion": 215,
+      "reasoning": 0,
+      "total": 996
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-213",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2496,
+    "usage": {
+      "prompt": 399,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 454
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-214",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が神経科学における長期抑圧（long-term depression）を指しており、うつ病（depression）の動物モデルではないため"
+    ],
+    "durationMs": 4211,
+    "usage": {
+      "prompt": 671,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 783
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-215",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression）を指しており、呼吸抑制や心機能抑制と同様に本レビュー対象外の用法である"
+    ],
+    "durationMs": 5871,
+    "usage": {
+      "prompt": 673,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 836
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-216",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いた抗うつ活性のスクリーニングが行われており、in vivoのうつ病モデル研究である可能性が高い"
+    ],
+    "durationMs": 6155,
+    "usage": {
+      "prompt": 649,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 823
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-217",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験が含まれており、in vivoモデルのうつ病研究である"
+    ],
+    "durationMs": 7063,
+    "usage": {
+      "prompt": 783,
+      "completion": 202,
+      "reasoning": 0,
+      "total": 985
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-218",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究はマウスを用いた心臓毒性（cardiotoxicity）に関するものであり、うつ病（depression）のin vivoモデルではない。「depression」が心機能抑制（cardiac depression）を意味している可能性があるが、抄録全体から判断すると、対象は抗がん剤の心毒性であり、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 7154,
+    "usage": {
+      "prompt": 798,
+      "completion": 213,
+      "reasoning": 0,
+      "total": 1011
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-219",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などの生理的抑制を指しており、うつ病（depression as a mental disorder）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 6643,
+    "usage": {
+      "prompt": 1160,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 1346
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-220",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸器疾患に関連する臨床症状（例：抑うつ状態ではなく、病態による活動低下）を指しており、うつ病の動物モデルではない。対象はヤギであり、うつ病の研究ではない。"
+    ],
+    "durationMs": 4952,
+    "usage": {
+      "prompt": 760,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 895
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-221",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "うつ病の動物モデルに関する記述がなく、タイトルからうつ病との関連が不明である"
+    ],
+    "durationMs": 3515,
+    "usage": {
+      "prompt": 420,
+      "completion": 88,
+      "reasoning": 0,
+      "total": 508
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-222",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ラット心臓におけるパルミチン酸の代謝に関する研究である"
+    ],
+    "durationMs": 4608,
+    "usage": {
+      "prompt": 411,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 508
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-223",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様行動の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではないため"
+    ],
+    "durationMs": 5979,
+    "usage": {
+      "prompt": 842,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 1003
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-224",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 2654,
+    "usage": {
+      "prompt": 404,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 461
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-225",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3621,
+    "usage": {
+      "prompt": 405,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 501
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-226",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 3724,
+    "usage": {
+      "prompt": 403,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 454
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-227",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する用語が含まれておらず、抗腫瘍化合物の作用機序に関する研究であるため、うつ病のin vivoモデルの研究ではないと判断される"
+    ],
+    "durationMs": 3282,
+    "usage": {
+      "prompt": 407,
+      "completion": 78,
+      "reasoning": 0,
+      "total": 485
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-228",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（マウスおよびラット）を用いた研究であり、対象がヒトではなく、呼吸性抑圧などの他の「抑うつ」ではない。"
+    ],
+    "durationMs": 5899,
+    "usage": {
+      "prompt": 829,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 996
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-229",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は体重増加の抑制（depression of body weight gain）を指しており、うつ病モデルの研究ではない。対象はラットだが、うつ病のin vivoモデルに関する研究ではない。"
+    ],
+    "durationMs": 4675,
+    "usage": {
+      "prompt": 719,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 842
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-230",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が昆虫の跳躍メカニズムに関する動物行動学的研究であり、うつ病のin vivoモデルを対象としていない"
+    ],
+    "durationMs": 4504,
+    "usage": {
+      "prompt": 826,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 949
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-231",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象文献は不安と記憶に関する動物実験であり、うつ病（depression）を主要な評価項目としていない。抄録内で「depression」が糖尿病関連の神経学的問題の一例として言及されているが、実際にうつ病モデルを用いた実験や評価は行われていない。"
+    ],
+    "durationMs": 6108,
+    "usage": {
+      "prompt": 533,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 701
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-232",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸・循環器系の抑制ではなくうつ病を指しているか不明だが、抄録中の「depressed intestinal absorption」は胆汁酸吸収の抑制を意味しており、うつ病モデルではない。対象はラットだが、うつ病の in vivo モデルに関する記述は一切ない。"
+    ],
+    "durationMs": 5310,
+    "usage": {
+      "prompt": 491,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 643
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-233",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、末梢神経損傷後の筋紡錘求心性線維の生理学的変化を調べた研究である。また、「depression」はシナプス効力の抑制（depression of the pre- and postsynaptic components）を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 6156,
+    "usage": {
+      "prompt": 780,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 956
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-234",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウス（in vivo動物モデル）を用いてうつ病関連行動を評価しており、うつ病が呼吸抑制などを指していない"
+    ],
+    "durationMs": 5043,
+    "usage": {
+      "prompt": 988,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 1115
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-235",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制などを指しており、うつ病モデルではないと明確に判断できる",
+      "動物実験ではあるが、うつ病（depression）のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 5108,
+    "usage": {
+      "prompt": 724,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 852
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-236",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病様行動の動物モデルであり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 7568,
+    "usage": {
+      "prompt": 686,
+      "completion": 214,
+      "reasoning": 0,
+      "total": 900
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-237",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトに関するインタビュー記事であり、うつ病のin vivo動物モデルを対象とした研究ではない"
+    ],
+    "durationMs": 5920,
+    "usage": {
+      "prompt": 634,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 798
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-238",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ラットにおける門脈体循環シャント後の肝臓の形態計測に関する研究である。「depression」の語は本抄録中に「reticuloendothelial system」の抑制を指す可能性があるが、これは精神医学的・行動学的な「うつ病」ではなく、除外基準に該当する。"
+    ],
+    "durationMs": 5758,
+    "usage": {
+      "prompt": 617,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 779
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-239",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経伝達の抑制を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4327,
+    "usage": {
+      "prompt": 730,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 839
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-240",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく皮質拡延性抑制（cortical spreading depression）を指しており、精神疾患の動物モデルではない"
+    ],
+    "durationMs": 5199,
+    "usage": {
+      "prompt": 751,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 898
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-241",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルを使用していない"
+    ],
+    "durationMs": 3889,
+    "usage": {
+      "prompt": 711,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 807
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-242",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録から、うつ病（depression）に関する動物モデルの研究であるという根拠が全く見当たらない。また、「depression」の語が含まれておらず、腎臓のアミノ酸輸送に関する研究であり、対象がうつ病ではないと判断される。"
+    ],
+    "durationMs": 3719,
+    "usage": {
+      "prompt": 412,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 508
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-243",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 4845,
+    "usage": {
+      "prompt": 479,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 613
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-244",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制（respiratory depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4380,
+    "usage": {
+      "prompt": 602,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 711
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-245",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の病因および治療に関連する中枢神経系における5-HT(1A)受容体遺伝子の発現をマウスを用いてin vivoで解析しており、動物モデルを用いたうつ病関連研究である"
+    ],
+    "durationMs": 7688,
+    "usage": {
+      "prompt": 767,
+      "completion": 226,
+      "reasoning": 0,
+      "total": 993
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-246",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、マウスの扁桃体におけるシナプス可塑性のメカニズムに焦点を当てた研究である",
+      "抄録中に「depression」という語はlong-term depression (LTD) という神経生理学的現象を指しており、うつ病（depression）とは無関係である"
+    ],
+    "durationMs": 6011,
+    "usage": {
+      "prompt": 775,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 945
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-247",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器系の機能低下（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4252,
+    "usage": {
+      "prompt": 727,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 837
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-248",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢神経抑制（central nervous system depressant）を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病のin vivoモデルではなく、抗不安および運動抑制活性の評価にとどまる"
+    ],
+    "durationMs": 5949,
+    "usage": {
+      "prompt": 640,
+      "completion": 173,
+      "reasoning": 0,
+      "total": 813
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-249",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」や動物モデルに関する記述が全くなく、対象が生体外実験（アルブミンの熱変性阻害）であると推測されるため"
+    ],
+    "durationMs": 3110,
+    "usage": {
+      "prompt": 410,
+      "completion": 74,
+      "reasoning": 0,
+      "total": 484
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-250",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "in vitro研究であり、in vivoモデルではない"
+    ],
+    "durationMs": 4303,
+    "usage": {
+      "prompt": 409,
+      "completion": 88,
+      "reasoning": 0,
+      "total": 497
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-251",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がうつ病ではなく、脳虚血および血小板反応性に関する研究である",
+      "「depression」が文中で「eNOS depression」として使われているが、これは機能低下を意味し、うつ病を指していない"
+    ],
+    "durationMs": 5306,
+    "usage": {
+      "prompt": 829,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 976
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-252",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなく、in vitro（初代培養細胞）を用いた実験であるため"
+    ],
+    "durationMs": 5194,
+    "usage": {
+      "prompt": 784,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 896
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-253",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「animal model」と明記されており、うつ病の動物モデルに関する研究であることが明確"
+    ],
+    "durationMs": 3593,
+    "usage": {
+      "prompt": 405,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 496
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-254",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や免疫抑制などの医学的意味（immune-depressive disease）で使われており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4244,
+    "usage": {
+      "prompt": 684,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 792
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-255",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、犬における性機能とホルモン調節に関する研究である",
+      "「depression」が用いられておらず、うつ病とは無関係"
+    ],
+    "durationMs": 3026,
+    "usage": {
+      "prompt": 889,
+      "completion": 76,
+      "reasoning": 0,
+      "total": 965
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-256",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がマラリア（感染症）に関する研究であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3978,
+    "usage": {
+      "prompt": 615,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 714
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-257",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、胎児発生とミトコンドリア機能に関する研究である"
+    ],
+    "durationMs": 2623,
+    "usage": {
+      "prompt": 759,
+      "completion": 52,
+      "reasoning": 0,
+      "total": 811
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-258",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression」や「うつ」に関連する用語が含まれておらず、抄録が存在しないため動物モデルのうつ病研究かどうか判断できないが、薬剤名（embikhin, sarcolysin, asalin）から抗がん剤や化学療法剤の副作用評価を示唆しており、うつ病モデルの研究とは考えにくい"
+    ],
+    "durationMs": 4483,
+    "usage": {
+      "prompt": 408,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-259",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラット（in vivo動物モデル）を用いたうつ病関連の研究であり、ヒト研究ではないため"
+    ],
+    "durationMs": 5528,
+    "usage": {
+      "prompt": 755,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 903
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-260",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ウサギを用いた血栓症および抗凝固療法の研究である"
+    ],
+    "durationMs": 4610,
+    "usage": {
+      "prompt": 414,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 529
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-261",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経科学における長期抑圧（Long-term depression, LTD）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4248,
+    "usage": {
+      "prompt": 656,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 773
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-262",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物（スズメ）であるが、うつ病（depression）ではなく近親交配劣勢（inbreeding depression）に関する研究であり、精神疾患としてのうつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4955,
+    "usage": {
+      "prompt": 710,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 842
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-263",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が脳内のグルコース利用の「抑制」を指しており、うつ病モデルではない",
+      "研究対象は健康ラットであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4518,
+    "usage": {
+      "prompt": 876,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 1003
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-264",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関するin vivo動物実験であり、うつ病の行動および神経化学的変化を評価している"
+    ],
+    "durationMs": 7056,
+    "usage": {
+      "prompt": 674,
+      "completion": 209,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-265",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫抑制（immune depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3791,
+    "usage": {
+      "prompt": 722,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 824
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-266",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "抄録に「遺伝的に修飾された5-HT7受容体欠損マウス」の使用が記載されており、うつ病のin vivo動物モデル研究の可能性があるが、うつ病そのものへの言及が明確でないため、フルテキスト確認が必要"
+    ],
+    "durationMs": 5344,
+    "usage": {
+      "prompt": 707,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 858
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-267",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、免疫応答と核酸代謝に関する研究である"
+    ],
+    "durationMs": 4679,
+    "usage": {
+      "prompt": 430,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 554
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-268",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ペニシリン投与による明るさ識別学習障害を調べた研究である"
+    ],
+    "durationMs": 4265,
+    "usage": {
+      "prompt": 407,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 518
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-269",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれていないため、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2229,
+    "usage": {
+      "prompt": 398,
+      "completion": 50,
+      "reasoning": 0,
+      "total": 448
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-270",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す証拠がない"
+    ],
+    "durationMs": 3491,
+    "usage": {
+      "prompt": 395,
+      "completion": 54,
+      "reasoning": 0,
+      "total": 449
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-271",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的な抑制効果（adenosineの抑制作用）を指しており、うつ病モデルではない",
+      "うつ病（depression）のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5025,
+    "usage": {
+      "prompt": 584,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 722
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-272",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病治療に関するレビューであり、in vivo動物モデルの研究ではない"
+    ],
+    "durationMs": 4336,
+    "usage": {
+      "prompt": 723,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 827
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-273",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される",
+      "タイトルから抗不整脈薬に関する心臓の電生理学的研究と推測され、うつ病とは無関係"
+    ],
+    "durationMs": 3648,
+    "usage": {
+      "prompt": 452,
+      "completion": 84,
+      "reasoning": 0,
+      "total": 536
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-274",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経応答の抑制を指しており、うつ病モデルではない",
+      "対象がネコであるが、うつ病のin vivoモデルとしての記載はなく、高熱による神経応答の抑制を調べた実験である"
+    ],
+    "durationMs": 5342,
+    "usage": {
+      "prompt": 589,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 738
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-275",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivo動物モデルのうつ病研究ではなく、細胞株（NG108-15細胞）を用いたin vitro実験であるため"
+    ],
+    "durationMs": 4300,
+    "usage": {
+      "prompt": 906,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 1022
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-276",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、免疫応答におけるT細胞の役割を調べた動物実験である"
+    ],
+    "durationMs": 2515,
+    "usage": {
+      "prompt": 651,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 710
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-277",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制などうつ病以外の文脈で使用されており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4171,
+    "usage": {
+      "prompt": 706,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 819
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-278",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから動物実験におけるうつ病モデルに関する研究であると判断できる根拠がなく、獣医学的な有害事象の概要に関するものと推測されるため"
+    ],
+    "durationMs": 4803,
+    "usage": {
+      "prompt": 403,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 519
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-279",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、両生類（ヒキガエルのオタマジャクシ）に対するゴイトロゲンの作用を調べた研究である"
+    ],
+    "durationMs": 4359,
+    "usage": {
+      "prompt": 409,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 530
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-280",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制（growth depression）を指しており、うつ病モデルではない",
+      "対象はブロイラー鶏だが、うつ病のin vivoモデルに関する研究ではない",
+      "呼吸性または心臓性のdepressionではなくとも、成長抑制の文脈であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 6551,
+    "usage": {
+      "prompt": 855,
+      "completion": 194,
+      "reasoning": 0,
+      "total": 1049
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-281",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（ラット）を用いた研究であり、対象が明確に動物である",
+      "「depression」が呼吸抑制や心機能低下ではなく、うつ様行動を指している"
+    ],
+    "durationMs": 6386,
+    "usage": {
+      "prompt": 673,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 841
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-282",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではないため除外"
+    ],
+    "durationMs": 3783,
+    "usage": {
+      "prompt": 827,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 920
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-283",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が神経科学における符号化精度の理論的・計算的研究であり、うつ病のin vivo動物モデルを対象としていない"
+    ],
+    "durationMs": 2753,
+    "usage": {
+      "prompt": 601,
+      "completion": 63,
+      "reasoning": 0,
+      "total": 664
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-284",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病のin vivo動物モデルではなく、ウサギの心臓を用いた循環器系の実験である。また、「depression」は本抄録に登場せず、うつ病とは無関係である。"
+    ],
+    "durationMs": 5131,
+    "usage": {
+      "prompt": 692,
+      "completion": 88,
+      "reasoning": 0,
+      "total": 780
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-285",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋収縮抑制（systolic contractile depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4627,
+    "usage": {
+      "prompt": 958,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 1060
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-286",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから、研究対象が血圧および血管拡張薬の低血圧反応であり、うつ病の動物モデルに関するものではないと判断される",
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性があるが、本タイトルでは「hypotensive responses（低血圧反応）」が焦点であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 7295,
+    "usage": {
+      "prompt": 407,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 582
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-287",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、覚醒や神経生理学的メカニズムに焦点を当てた研究である"
+    ],
+    "durationMs": 2693,
+    "usage": {
+      "prompt": 994,
+      "completion": 62,
+      "reasoning": 0,
+      "total": 1056
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-288",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、薬物相互作用および生理学的影響（血圧、心拍数など）を評価した動物実験である。うつ病の評価やモデルが含まれていない。"
+    ],
+    "durationMs": 6612,
+    "usage": {
+      "prompt": 699,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 843
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-289",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の語が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "抄録が存在せず、内容を評価できないが、タイトルから判断して呼吸・心機能などの「depression」とも関連しない"
+    ],
+    "durationMs": 3553,
+    "usage": {
+      "prompt": 410,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 503
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-290",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などではなく、うつ病を指しているか不明だが、文脈から「uridylate kinase activityの低下（depression）」を意味しており、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 5424,
+    "usage": {
+      "prompt": 447,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 582
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-291",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、ラットの下垂体前葉における細胞増殖の影響を調べた研究である"
+    ],
+    "durationMs": 4563,
+    "usage": {
+      "prompt": 474,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 591
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-292",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が腫瘍成長の抑制（depression of tumor growth）を指しており、うつ病（depression）の動物モデルに関する研究ではない。対象は腫瘍と炎症の関係であり、うつ病とは無関係である。"
+    ],
+    "durationMs": 5296,
+    "usage": {
+      "prompt": 658,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 802
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-293",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depresses」や「depression」は心臓収縮抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 7734,
+    "usage": {
+      "prompt": 852,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 1022
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-294",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "Wistar-Kyotoラットを用いたうつ病の動物モデルに関する研究であり、in vivoでの行動評価（オープンフィールドテスト、強制水泳テスト）が含まれている。"
+    ],
+    "durationMs": 4671,
+    "usage": {
+      "prompt": 656,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 786
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-295",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "「depression」が回避行動の抑制を指しており、呼吸抑制や心機能抑制などの非該当用途ではない。マウスを用いたin vivo動物実験である。"
+    ],
+    "durationMs": 6626,
+    "usage": {
+      "prompt": 509,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 671
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-296",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が心機能の抑制（cardiac depression）を指しており、うつ病モデルではない",
+      "対象はラットであるが、うつ病のin vivoモデルではなく、拘束ストレスによる心臓および胃粘膜への影響を評価した研究"
+    ],
+    "durationMs": 5273,
+    "usage": {
+      "prompt": 711,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 857
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-297",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、薬物動態を評価した健康なイヌを用いた研究である"
+    ],
+    "durationMs": 5422,
+    "usage": {
+      "prompt": 889,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 1037
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-298",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病モデルではなく、心筋収縮力および活動電位に関するものであり、「depression」が精神疾患としてのうつ病を指していない"
+    ],
+    "durationMs": 6826,
+    "usage": {
+      "prompt": 1147,
+      "completion": 193,
+      "reasoning": 0,
+      "total": 1340
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-299",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はノルアドレナリン放出の抑制（生理的抑制）を指しており、うつ病モデルではない",
+      "対象は脳損傷後の生理学的変化を調べた動物実験だが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5655,
+    "usage": {
+      "prompt": 860,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 1014
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-300",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病研究であり、動物モデルを用いたin vivo研究ではない"
+    ],
+    "durationMs": 4072,
+    "usage": {
+      "prompt": 578,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 688
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-301",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2256,
+    "usage": {
+      "prompt": 404,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 455
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-302",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4077,
+    "usage": {
+      "prompt": 747,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 855
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-303",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経生理学的現象（paired-pulse depression）を指しており、うつ病モデルではない",
+      "対象はラットだが、うつ病のin vivoモデルに関する記述は一切ない",
+      "抄録で言及されている疾患は自閉症、統合失調症、失読症であり、うつ病は含まれていない"
+    ],
+    "durationMs": 8692,
+    "usage": {
+      "prompt": 636,
+      "completion": 241,
+      "reasoning": 0,
+      "total": 877
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-304",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫抑制（immune-depressive effect）を指しており、うつ病（depression）モデルではない。対象は魚類だが、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 4226,
+    "usage": {
+      "prompt": 697,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 813
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-305",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3668,
+    "usage": {
+      "prompt": 398,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 494
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-306",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病の動物モデルではない",
+      "「depression」は気分障害ではなく、職業環境における症状の一つとして記載されている"
+    ],
+    "durationMs": 5605,
+    "usage": {
+      "prompt": 894,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 1032
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-307",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経伝達の抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 3671,
+    "usage": {
+      "prompt": 813,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 910
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-308",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または心臓性の抑制（例：rate-dependent depression of Vmax）を指しており、うつ病モデルではない",
+      "対象は心臓電気生理学に関する動物実験であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5200,
+    "usage": {
+      "prompt": 835,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 981
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-309",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は長期抑圧（long-term depression, LTD）という神経生理学的現象を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5667,
+    "usage": {
+      "prompt": 667,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 825
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-310",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が生体外（in vitro）組織（子牛冠状動脈）であり、うつ病のin vivo動物モデルではない",
+      "「depression」は収縮反応の抑制を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 6218,
+    "usage": {
+      "prompt": 836,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 1012
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-311",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いた強制泳ぐテストといううつ病の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない。"
+    ],
+    "durationMs": 5765,
+    "usage": {
+      "prompt": 832,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 996
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-312",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的な抑制現象（例：シナプス抑制）を指しており、うつ病モデルではない",
+      "研究対象が魚の脳切片（in vitro）であり、in vivoのうつ病動物モデルではない",
+      "人間以外の動物を使用しているが、うつ病のモデルとしての記載が全くない"
+    ],
+    "durationMs": 5554,
+    "usage": {
+      "prompt": 702,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 863
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-313",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がハンチントン病であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 3854,
+    "usage": {
+      "prompt": 725,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 821
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-314",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、カプサイシンによる感覚神経の脱感作を調べた動物実験である"
+    ],
+    "durationMs": 4454,
+    "usage": {
+      "prompt": 683,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 807
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-315",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する動物モデルの研究ではなく、ハエの視覚神経における残像効果の研究である。「depression」という語が神経応答の抑制を指しており、気分障害としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5108,
+    "usage": {
+      "prompt": 946,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 1090
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-316",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が猫の視覚野であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 3703,
+    "usage": {
+      "prompt": 620,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 717
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-317",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はサイトカイン産生の低下（tumor-induced depression）を指しており、うつ病モデルではない",
+      "対象は前立腺がんモデルであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4672,
+    "usage": {
+      "prompt": 847,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 976
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-318",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、肝臓の成長と細胞増殖抑制に関する研究である"
+    ],
+    "durationMs": 2703,
+    "usage": {
+      "prompt": 527,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 580
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-319",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 3502,
+    "usage": {
+      "prompt": 602,
+      "completion": 90,
+      "reasoning": 0,
+      "total": 692
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-320",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）やその動物モデルに関する記述がなく、ウイルスRNAに関する研究であることが示されている"
+    ],
+    "durationMs": 4183,
+    "usage": {
+      "prompt": 408,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 522
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-321",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、網内系貪食活性の抑制（生理的抑制）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4747,
+    "usage": {
+      "prompt": 711,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 836
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-322",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」や「うつ」などのキーワードが含まれておらず、抄録がないため動物モデルを用いたうつ病研究かどうか判断できない"
+    ],
+    "durationMs": 2696,
+    "usage": {
+      "prompt": 402,
+      "completion": 64,
+      "reasoning": 0,
+      "total": 466
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-323",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓の活動抑制（心臓抑制）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4259,
+    "usage": {
+      "prompt": 881,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 996
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-324",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない",
+      "抄録に「depression」の言及がなく、研究対象は血小板と好中球の接着阻害因子である"
+    ],
+    "durationMs": 3725,
+    "usage": {
+      "prompt": 648,
+      "completion": 74,
+      "reasoning": 0,
+      "total": 722
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-325",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫機能の低下（immunocompetenceの抑制）を指しており、うつ病モデルではない",
+      "対象はブロイラー鶏だが、うつ病のin vivoモデルではなく、熱ストレス下での免疫応答の研究である"
+    ],
+    "durationMs": 5424,
+    "usage": {
+      "prompt": 848,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 990
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-326",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が医療外来患者（人間）であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 5365,
+    "usage": {
+      "prompt": 604,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 750
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-327",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、ニコチンによる運動活動の抑制（locomotor activity depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4704,
+    "usage": {
+      "prompt": 770,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 898
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-328",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が昆虫（シロカイガラムシ）の共生微生物に関する研究であり、うつ病のin vivoモデルを用いた動物研究ではない"
+    ],
+    "durationMs": 5176,
+    "usage": {
+      "prompt": 621,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 761
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-329",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などの文脈ではなく、うつ病モデルに関する動物研究である必要があるが、本研究では「depression」はコリンエステラーゼ活性の抑制（cholinesterase activity depression）を指しており、うつ病モデルではない。また、行動評価も熱板試験とストレス誘発性鎮痛に焦点を当てており、うつ病関連の行動評価ではない。"
+    ],
+    "durationMs": 7131,
+    "usage": {
+      "prompt": 685,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 864
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-330",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、熱傷によるアルブミン漏出に関する研究である"
+    ],
+    "durationMs": 5110,
+    "usage": {
+      "prompt": 787,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 933
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-331",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録から、うつ病（depression）に関する動物実験の内容が確認できない。対象は角膜におけるNaK-ATPase活性の組織化学的所見であり、うつ病モデルとは無関係と判断される。"
+    ],
+    "durationMs": 3921,
+    "usage": {
+      "prompt": 419,
+      "completion": 84,
+      "reasoning": 0,
+      "total": 503
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-332",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する動物研究であり、ヒト研究や呼吸・循環器系の抑制を指す「depression」ではない"
+    ],
+    "durationMs": 6209,
+    "usage": {
+      "prompt": 672,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 834
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-333",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2320,
+    "usage": {
+      "prompt": 420,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 473
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-334",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 5253,
+    "usage": {
+      "prompt": 517,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 665
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-335",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、抄録が存在しないため、うつ病のin vivo動物モデルに関する研究かどうか判断できない"
+    ],
+    "durationMs": 2785,
+    "usage": {
+      "prompt": 399,
+      "completion": 63,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-336",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は精神疾患としてのうつ病ではなく、銅中毒による抑うつ状態や全身状態の悪化を指していると判断される"
+    ],
+    "durationMs": 5425,
+    "usage": {
+      "prompt": 582,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 721
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-337",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経の抑制（neuronal depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5580,
+    "usage": {
+      "prompt": 582,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 737
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-338",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「中枢神経抑制作用（central nervous depressive action）」を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4024,
+    "usage": {
+      "prompt": 673,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 784
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-339",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の低下（regional depression in ischemic zone function）を指しており、うつ病モデルではない",
+      "対象はイヌを用いた心筋虚血・再灌流モデルであり、うつ病のin vivoモデルではない",
+      "うつ病（depression）に関する動物モデル研究ではない"
+    ],
+    "durationMs": 5481,
+    "usage": {
+      "prompt": 804,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 962
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-340",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない。研究対象はサルガトキシンの薬理作用であり、うつ病とは無関係である。"
+    ],
+    "durationMs": 3155,
+    "usage": {
+      "prompt": 912,
+      "completion": 68,
+      "reasoning": 0,
+      "total": 980
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-341",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経生理学的な抑制（興奮の抑制）を指しており、うつ病モデルではない",
+      "対象は新生児ラットの運動ニューロンであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5007,
+    "usage": {
+      "prompt": 599,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 735
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-342",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、循環抑制（hypotensive and bradycardic effects）を調べた動物実験である。「depression」の語は本抄録には含まれておらず、呼吸抑制や心機能抑制などの「depression」とも無関係であるが、うつ病モデルの研究ではないため除外対象となる。"
+    ],
+    "durationMs": 5188,
+    "usage": {
+      "prompt": 618,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 731
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-343",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、アナフィラキシー反応におけるヒスタミン放出に関する研究である"
+    ],
+    "durationMs": 7327,
+    "usage": {
+      "prompt": 467,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 653
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-344",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2637,
+    "usage": {
+      "prompt": 406,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 459
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-345",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が猫の視覚野の神経可塑性に関する研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5820,
+    "usage": {
+      "prompt": 696,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 862
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-346",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "タイトルに「depression（うつ病）」が含まれておらず、対象がウサギでの体温調節作用の研究である"
+    ],
+    "durationMs": 3176,
+    "usage": {
+      "prompt": 402,
+      "completion": 68,
+      "reasoning": 0,
+      "total": 470
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-347",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから、研究対象が七面鳥（動物）であるが、うつ病（depression）に関する研究ではなく、銅欠乏食とアスコルビン酸の動脈への影響を観察している"
+    ],
+    "durationMs": 6857,
+    "usage": {
+      "prompt": 412,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 553
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-348",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は酵素活性の抑制を指しており、うつ病モデルに関する動物研究ではない"
+    ],
+    "durationMs": 4219,
+    "usage": {
+      "prompt": 701,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 809
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-349",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病研究であり、動物モデルではない"
+    ],
+    "durationMs": 5341,
+    "usage": {
+      "prompt": 670,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 815
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-350",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病の動物モデルに関する記述が見られず、肝酵素と甲状腺機能に関する研究と推測されるため"
+    ],
+    "durationMs": 2671,
+    "usage": {
+      "prompt": 404,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 463
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-351",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病様ラットを用いたin vivo動物実験であり、対象が明確に動物モデルである"
+    ],
+    "durationMs": 7473,
+    "usage": {
+      "prompt": 720,
+      "completion": 200,
+      "reasoning": 0,
+      "total": 920
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-352",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、高血圧ウサギを用いた循環器系の研究である"
+    ],
+    "durationMs": 4243,
+    "usage": {
+      "prompt": 674,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 790
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-353",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5465,
+    "usage": {
+      "prompt": 608,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 753
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-354",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が高血圧ラットにおける降圧作用の評価であり、うつ病のin vivoモデルではない",
+      "うつ病モデル動物を用いておらず、うつ病そのものに関する研究ではない"
+    ],
+    "durationMs": 7208,
+    "usage": {
+      "prompt": 641,
+      "completion": 212,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-355",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が運動調整の抑制（motor impairment）を指しており、うつ病モデルではない",
+      "対象がラットであるが、うつ病のin vivoモデルに関する記述は一切ない"
+    ],
+    "durationMs": 5911,
+    "usage": {
+      "prompt": 798,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-356",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、シナプス可塑性における長期抑圧（long-term depression, LTD）を指している",
+      "対象はラットの脳切片（in vitro）であり、in vivoうつ病モデルではない"
+    ],
+    "durationMs": 5909,
+    "usage": {
+      "prompt": 779,
+      "completion": 173,
+      "reasoning": 0,
+      "total": 952
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-357",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデルに関する研究であり、in vivoでの強制水泳試験（forced swim test）により抗うつ様効果を評価している"
+    ],
+    "durationMs": 6161,
+    "usage": {
+      "prompt": 702,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 878
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-358",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能低下などの意味ではなく皮膚の基底細胞増殖活性の低下を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4707,
+    "usage": {
+      "prompt": 677,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 792
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-359",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患が「うつ病」ではなく、持続性内臓痛のモデルである。また、「depression」が出現しても排尿反射の軽微な抑制を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6204,
+    "usage": {
+      "prompt": 721,
+      "completion": 183,
+      "reasoning": 0,
+      "total": 904
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-360",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「inbreeding depression」はうつ病ではなく近交劣勢を指しており、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 3952,
+    "usage": {
+      "prompt": 752,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-361",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や関連する動物モデルの記載がなく、抄録が存在しないため、うつ病のin vivoモデル研究である可能性が極めて低い"
+    ],
+    "durationMs": 3104,
+    "usage": {
+      "prompt": 398,
+      "completion": 71,
+      "reasoning": 0,
+      "total": 469
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-362",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が聴覚電位の低下（生理学的抑制）を指しており、うつ病モデルではない",
+      "研究は聴覚毒性に関するもので、うつ病の動物モデルを対象としていない",
+      "対象はモルモットであり、うつ病の行動評価や病理モデルではない"
+    ],
+    "durationMs": 5809,
+    "usage": {
+      "prompt": 845,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 1009
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-363",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3907,
+    "usage": {
+      "prompt": 831,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 934
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-364",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫抑制を指しており、うつ病モデルではない。動物を用いたうつ病の研究ではない。"
+    ],
+    "durationMs": 5151,
+    "usage": {
+      "prompt": 648,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 793
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-365",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や心機能抑制など神経筋の抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5482,
+    "usage": {
+      "prompt": 673,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 830
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-366",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢抑制（central depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3903,
+    "usage": {
+      "prompt": 756,
+      "completion": 94,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-367",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経可塑性におけるlong-term depression（長期抑圧）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4387,
+    "usage": {
+      "prompt": 581,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 693
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-368",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "中国ハムスター細胞を用いたヒストン修飾の研究であり、うつ病とは無関係と判断される"
+    ],
+    "durationMs": 3439,
+    "usage": {
+      "prompt": 402,
+      "completion": 83,
+      "reasoning": 0,
+      "total": 485
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-369",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が行動活動の低下（depression of open-field activity）を指しており、うつ病モデルではないと判断される"
+    ],
+    "durationMs": 4211,
+    "usage": {
+      "prompt": 670,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 778
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-370",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はシナプス伝達の抑制（神経生理学的用語）を指しており、うつ病モデルではない",
+      "対象はアルツハイマー病関連の神経筋接合部の機能研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5394,
+    "usage": {
+      "prompt": 598,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 742
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-371",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4441,
+    "usage": {
+      "prompt": 675,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 774
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-372",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ラット精管におけるセロトニンの収縮反応への影響を調べた研究である。「depression」が出現する箇所は神経伝達の抑制（depressed responses）を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 6102,
+    "usage": {
+      "prompt": 593,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 754
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-373",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、エストラジオールによる未成熟ラット子宮におけるリボ核酸合成に関する研究である"
+    ],
+    "durationMs": 6174,
+    "usage": {
+      "prompt": 690,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 872
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-374",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が犬とウサギであり動物実験であるが、研究テーマが心血管作用であり、うつ病モデルの研究ではない。また、「depression」が含まれておらず、うつ病関連の内容が全く示されていない。"
+    ],
+    "durationMs": 4999,
+    "usage": {
+      "prompt": 401,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-375",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や心臓の機能低下を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5509,
+    "usage": {
+      "prompt": 483,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 581
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-376",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋収縮の抑制（cardiac depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3901,
+    "usage": {
+      "prompt": 856,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 962
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-377",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、抗うつ薬（MAOI）の効果を評価しているため"
+    ],
+    "durationMs": 6093,
+    "usage": {
+      "prompt": 648,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 827
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-378",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」が神経生理学的抑制（例：LTD）を指しており、うつ病モデルではない可能性が高い",
+      "対象が猫であり動物研究ではあるが、うつ病のin vivoモデルとは明確に記載されていない"
+    ],
+    "durationMs": 4806,
+    "usage": {
+      "prompt": 411,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 543
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-379",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病のin vivoモデルではなく、リチウム処理によるラット腎機能への影響を調べたものである。「depression」は腎細管の再吸収機能低下を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6037,
+    "usage": {
+      "prompt": 640,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 796
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-380",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした高血圧に関する遺伝子多型の研究であり、うつ病のin vivo動物モデルの研究ではない",
+      "「depression」は遺伝子発現の抑制を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 9472,
+    "usage": {
+      "prompt": 818,
+      "completion": 213,
+      "reasoning": 0,
+      "total": 1031
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-381",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、卵巣摘出ラットにおける発情行動に関する研究である"
+    ],
+    "durationMs": 4699,
+    "usage": {
+      "prompt": 430,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 537
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-382",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "タイトルに「depression」の用語が含まれていない"
+    ],
+    "durationMs": 2356,
+    "usage": {
+      "prompt": 408,
+      "completion": 48,
+      "reasoning": 0,
+      "total": 456
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-383",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病のin vivo動物モデルに関する記述が確認できない",
+      "免疫グロブリンおよびミエローマタンパク質に関する研究であり、うつ病とは無関係と判断される"
+    ],
+    "durationMs": 3734,
+    "usage": {
+      "prompt": 409,
+      "completion": 76,
+      "reasoning": 0,
+      "total": 485
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-384",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象文献はうつ病のin vivoモデルに関する研究ではなく、魚類の精子競争と近親交配回避に関する研究である"
+    ],
+    "durationMs": 4546,
+    "usage": {
+      "prompt": 792,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 915
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-385",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はサイトカイン産生の一時的な低下を指しており、うつ病モデルではない。動物実験ではあるが、うつ病（depression）の研究ではない。"
+    ],
+    "durationMs": 5613,
+    "usage": {
+      "prompt": 819,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 971
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-386",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット門脈の平滑筋収縮であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "抄録中に「depression」が出現するが、これは心臓・呼吸器系の抑制を指す用法ではなく、収縮力の低下を意味しており、うつ病とは無関係"
+    ],
+    "durationMs": 7514,
+    "usage": {
+      "prompt": 597,
+      "completion": 217,
+      "reasoning": 0,
+      "total": 814
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-387",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が代謝酵素活性の低下を指しており、うつ病モデルではない",
+      "研究対象はラットであるが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4610,
+    "usage": {
+      "prompt": 639,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 765
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-388",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、抗炎症・鎮痛作用および潰瘍形成性に関するラット研究である"
+    ],
+    "durationMs": 5015,
+    "usage": {
+      "prompt": 714,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 828
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-389",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから、対象がラットの乳がんモデルであり、うつ病のin vivoモデルに関する研究ではないと判断される。"
+    ],
+    "durationMs": 3855,
+    "usage": {
+      "prompt": 406,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 511
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-390",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、テストステロンおよびステロイド生成に関する動物実験であるため"
+    ],
+    "durationMs": 5844,
+    "usage": {
+      "prompt": 935,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 1055
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-391",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、妊娠ラットの大動脈におけるαアドレnergic受容体反応に関する研究である。"
+    ],
+    "durationMs": 6729,
+    "usage": {
+      "prompt": 771,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 968
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-392",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、ショウジョウバエを用いた寿命選抜実験であるため"
+    ],
+    "durationMs": 6018,
+    "usage": {
+      "prompt": 616,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 781
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-393",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究であり、抄録にラットを用いた実験が明記されているため"
+    ],
+    "durationMs": 7339,
+    "usage": {
+      "prompt": 1026,
+      "completion": 221,
+      "reasoning": 0,
+      "total": 1247
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-394",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）に関する記述がなく、動物モデルを用いたうつ病研究ではないと判断される"
+    ],
+    "durationMs": 2883,
+    "usage": {
+      "prompt": 427,
+      "completion": 61,
+      "reasoning": 0,
+      "total": 488
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-395",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」または「depression」に関する記載がなく、研究対象が動物モデルであるか不明である。また、タイトルから判断すると、ミトコンドリア膜のプロトン輸送に関する生化学的研究であり、うつ病とは無関係と見なされる。"
+    ],
+    "durationMs": 4099,
+    "usage": {
+      "prompt": 408,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 503
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-396",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が犬であり、うつ病の動物モデルに関する研究ではなく、腎臓異形成の症例報告である。また、「depression」は精神疾患としてのうつ病ではなく、一般的な抑うつ状態を指している可能性があるが、研究対象がうつ病モデルではないため除外される。"
+    ],
+    "durationMs": 6632,
+    "usage": {
+      "prompt": 563,
+      "completion": 195,
+      "reasoning": 0,
+      "total": 758
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-397",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルのうつ病研究ではなく、in vitroでのマクロファージ機能に関する研究である"
+    ],
+    "durationMs": 5008,
+    "usage": {
+      "prompt": 606,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 739
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-398",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がDNA合成の抑制を指しており、うつ病モデルではない",
+      "呼吸器や心臓の抑制ではなく細胞増殖の抑制を意味するが、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4499,
+    "usage": {
+      "prompt": 548,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 671
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-399",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性があるが、本抄録では「depression」が運動活動の抑制を意味しており、うつ病モデルではない。対象はマウスだが、うつ病のin vivoモデルに関する研究ではない。"
+    ],
+    "durationMs": 5596,
+    "usage": {
+      "prompt": 554,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 704
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-400",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく犬であるが、うつ病（depression）の研究ではなく、心電図におけるST-depression（虚血性変化）に関する記述であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 4681,
+    "usage": {
+      "prompt": 641,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 772
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-401",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、ヒト研究ではない"
+    ],
+    "durationMs": 5158,
+    "usage": {
+      "prompt": 803,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 946
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-402",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する用語が含まれておらず、抄録が存在しないため動物モデルでのうつ病研究かどうか判断できないが、タイトルから推測される内容（ヒストン、プロタミン、RNA合成）はうつ病モデルとは関連性が低く見える"
+    ],
+    "durationMs": 3981,
+    "usage": {
+      "prompt": 407,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 505
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-403",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋収縮抑制（cardiac depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 3976,
+    "usage": {
+      "prompt": 732,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 837
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-404",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく「inbreeding depression（近交劣勢）」を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5654,
+    "usage": {
+      "prompt": 663,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 809
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-405",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的現象（拡延性皮質抑制）を指しており、うつ病モデルではないと判断される"
+    ],
+    "durationMs": 4282,
+    "usage": {
+      "prompt": 401,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 505
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-406",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物モデルを用いたうつ病研究ではなく、分子インプリンティングとヘテロ接合体不足・雑種強勢に関する理論的考察である"
+    ],
+    "durationMs": 4183,
+    "usage": {
+      "prompt": 531,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 641
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-407",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「最大脱分極速度（Vmax）のレート依存性抑制」として用いられており、うつ病モデルではなく心臓の電気生理学的抑制を指している",
+      "対象はギニアピッグ心室組織であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 5743,
+    "usage": {
+      "prompt": 659,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 820
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-408",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は眼圧の低下（intraocular pressure depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4279,
+    "usage": {
+      "prompt": 701,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 819
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-409",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が骨髄抑制による細胞数の減少（myelosuppression）を指しており、うつ病（depression）の動物モデルではないため"
+    ],
+    "durationMs": 4689,
+    "usage": {
+      "prompt": 696,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 821
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-410",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制など精神疾患としてのうつ病を指していない",
+      "対象がニホンウナギであり、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4497,
+    "usage": {
+      "prompt": 713,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 834
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-411",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（5-HT受容体ノックアウトマウス）を用いた研究であり、行動性無気力（テールサスペションテストおよび強制水泳テスト）を評価している"
+    ],
+    "durationMs": 7320,
+    "usage": {
+      "prompt": 707,
+      "completion": 216,
+      "reasoning": 0,
+      "total": 923
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-412",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が筋収縮後の抑制（posttetanic twitch depression）を指しており、うつ病モデルではない。対象はカエルの骨格筋細胞であり、うつ病のin vivo動物モデルに関する研究ではない。"
+    ],
+    "durationMs": 4797,
+    "usage": {
+      "prompt": 730,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 864
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-413",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病関連の動物実験であり、うつ病モデルの文脈で睡眠覚醒周期を評価している"
+    ],
+    "durationMs": 6171,
+    "usage": {
+      "prompt": 929,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 1108
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-414",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能抑制などを指すものではなく、うつ病（depression）を指す場合にのみ対象となるが、本研究では「depression」は肝ミクロソーム酵素活性の低下を指しており、うつ病モデルではない。また、うつ病に関連する行動評価や神経生物学的指標は含まれていない。"
+    ],
+    "durationMs": 5926,
+    "usage": {
+      "prompt": 612,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 779
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-415",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 3989,
+    "usage": {
+      "prompt": 785,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 890
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-416",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病の動物モデルに関する研究かどうか不明である。モノアミンオキシダーゼやノルアドレナリンに関する研究ではあるが、うつ病との関連が明示されていない。"
+    ],
+    "durationMs": 3278,
+    "usage": {
+      "prompt": 416,
+      "completion": 85,
+      "reasoning": 0,
+      "total": 501
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-417",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4102,
+    "usage": {
+      "prompt": 946,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 1050
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-418",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病関連のin vivo動物実験であり、呼吸性または心臓性の「depression」ではない"
+    ],
+    "durationMs": 6681,
+    "usage": {
+      "prompt": 803,
+      "completion": 194,
+      "reasoning": 0,
+      "total": 997
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-419",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓の興奮伝導抑制を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 5468,
+    "usage": {
+      "prompt": 555,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 706
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-420",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がシナプス抑制（synaptic depression）を指しており、うつ病（depression）の動物モデルではない。また、研究対象はヒルの感覚細胞であり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 5020,
+    "usage": {
+      "prompt": 639,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 766
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-421",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivo動物モデル（マウス）を用いたうつ病研究であり、ヒト研究ではない"
+    ],
+    "durationMs": 5672,
+    "usage": {
+      "prompt": 792,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 956
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-422",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2478,
+    "usage": {
+      "prompt": 443,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 496
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-423",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が猫の膀胱神経節であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 2504,
+    "usage": {
+      "prompt": 541,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 594
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-424",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「inbreeding depression」はうつ病ではなく近親交配による適応度低下を指しており、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 5650,
+    "usage": {
+      "prompt": 742,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 900
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-425",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経活動の抑制を指しており、うつ病モデルではない",
+      "対象がイヌ（in vivo）だが、うつ病の動物モデル研究ではない"
+    ],
+    "durationMs": 4158,
+    "usage": {
+      "prompt": 407,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 520
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-426",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2854,
+    "usage": {
+      "prompt": 420,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 473
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-427",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2371,
+    "usage": {
+      "prompt": 409,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 464
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-428",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、糖尿病マウスを用いたインスリンとプロスチグミンの影響に関する研究である"
+    ],
+    "durationMs": 4084,
+    "usage": {
+      "prompt": 413,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 517
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-429",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動の動物モデルに関する研究であり、in vivo のうつ病モデルに該当する"
+    ],
+    "durationMs": 5876,
+    "usage": {
+      "prompt": 675,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 838
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-430",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない",
+      "in vitro細胞実験であり、対象がマウス肉腫由来細胞である"
+    ],
+    "durationMs": 4421,
+    "usage": {
+      "prompt": 412,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 534
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-431",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2257,
+    "usage": {
+      "prompt": 414,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 465
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-432",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または代謝性の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3642,
+    "usage": {
+      "prompt": 563,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 658
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-433",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、薬物乱用や覚醒・報酬回路に関する動物研究である"
+    ],
+    "durationMs": 6654,
+    "usage": {
+      "prompt": 729,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 851
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-434",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoうつ病モデルの動物実験ではなく、カエル胃粘膜を用いたin vitro実験であり、うつ病に関する記述もない"
+    ],
+    "durationMs": 4263,
+    "usage": {
+      "prompt": 663,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 777
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-435",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルに関する研究であり、5-HT(4)受容体ノックアウトマウスを用いてセロトニン神経の機能を評価している。抄録内で「depression」が精神疾患として明確に言及されており、呼吸性うつや心機能低下などの非精神医学的用法ではない。"
+    ],
+    "durationMs": 5821,
+    "usage": {
+      "prompt": 827,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 997
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-436",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指している",
+      "対象がラットであるものの、うつ病モデルではなくコカイン投与による神経適応を調べた研究"
+    ],
+    "durationMs": 6427,
+    "usage": {
+      "prompt": 969,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 1128
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-437",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2209,
+    "usage": {
+      "prompt": 404,
+      "completion": 49,
+      "reasoning": 0,
+      "total": 453
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-438",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「Depression」が血糖値の低下（glucose levelsの減少）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4073,
+    "usage": {
+      "prompt": 792,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 896
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-439",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoではなくin vitro（培養神経細胞）を用いた研究であり、in vivoモデルではないが、抄録中に「mouse hippocampal and prefrontal neurons」とあるため動物由来の細胞を使用しており、判断に迷う可能性がある。ただし、明確にin vivoではないため除外すべきだが、スクリーニングの感度を最優先し、全文確認が必要な可能性があるため包含する。"
+    ],
+    "durationMs": 6123,
+    "usage": {
+      "prompt": 612,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 787
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-440",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "樹鼩（tree shrew）を用いたin vivo動物実験であり、うつ病関連の神経内分泌機構を検討している"
+    ],
+    "durationMs": 4700,
+    "usage": {
+      "prompt": 760,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-441",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "抄録に「rodents（齧歯類）」を用いたin vivo動物実験が明記されており、うつ病モデルに関する研究であるため"
+    ],
+    "durationMs": 4854,
+    "usage": {
+      "prompt": 768,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 893
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-442",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は肝臓の薬物代謝の抑制を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5044,
+    "usage": {
+      "prompt": 594,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 708
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-443",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や心臓の機能低下（心筋虚血後の収縮低下）を指しており、うつ病モデルではない",
+      "対象が動物（犬）ではあるが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4884,
+    "usage": {
+      "prompt": 738,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 872
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-444",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、脂質低下作用に関する研究であることが示されているため、うつ病のin vivo動物モデルの研究ではないと判断される"
+    ],
+    "durationMs": 3064,
+    "usage": {
+      "prompt": 417,
+      "completion": 76,
+      "reasoning": 0,
+      "total": 493
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-445",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、胃酸分泌に関する動物実験である"
+    ],
+    "durationMs": 6088,
+    "usage": {
+      "prompt": 516,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 680
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-446",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がうつ病ではなく、海馬の脱求心性と学習記憶障害に関する研究である",
+      "抄録中に「depression」という語が「グルコース利用の低下（glucose depression）」を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 5285,
+    "usage": {
+      "prompt": 904,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 1054
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-447",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病のin vivoモデル研究であり、ヒト研究や呼吸・循環器系の抑制を指す「depression」ではない"
+    ],
+    "durationMs": 7344,
+    "usage": {
+      "prompt": 1187,
+      "completion": 212,
+      "reasoning": 0,
+      "total": 1399
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-448",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「inbreeding depression（近交劣勢）」を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5177,
+    "usage": {
+      "prompt": 695,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 840
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-449",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が手術後の活動低下や摂食・飲水の減少を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4306,
+    "usage": {
+      "prompt": 561,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 660
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-450",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がサル（ヒト以外の霊長類）であるが、研究の焦点が心血管機能の抑制（cardiovascular depression）であり、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4572,
+    "usage": {
+      "prompt": 720,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 841
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-451",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病のin vivoモデルに関する研究であり、動物実験であるため包含基準を満たす。"
+    ],
+    "durationMs": 5654,
+    "usage": {
+      "prompt": 756,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 919
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-452",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経細胞増殖の低下を指しており、うつ病（depression）の動物モデルではない",
+      "研究対象は視覚系の再生・成長であり、うつ病とは無関係"
+    ],
+    "durationMs": 4999,
+    "usage": {
+      "prompt": 842,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 974
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-453",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、内リンパ嚢直流電位（ESP）の低下を指しており、対象外の生理学的抑制である。動物実験ではあるが、うつ病モデルではない。"
+    ],
+    "durationMs": 5685,
+    "usage": {
+      "prompt": 743,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 891
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-454",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、中枢神経抑制（central depressive action）を指しており、呼吸抑制や心機能抑制と同様に除外対象である"
+    ],
+    "durationMs": 5717,
+    "usage": {
+      "prompt": 635,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 799
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-455",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、ヒト研究ではない。うつ病は呼吸抑制や心機能抑制ではなく、大うつ病を指している。"
+    ],
+    "durationMs": 7262,
+    "usage": {
+      "prompt": 747,
+      "completion": 216,
+      "reasoning": 0,
+      "total": 963
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-456",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルに関する記述がない"
+    ],
+    "durationMs": 3366,
+    "usage": {
+      "prompt": 488,
+      "completion": 84,
+      "reasoning": 0,
+      "total": 572
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-457",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、シナプス伝達の抑制（long-lasting depression）を指しており、呼吸性または心臓性の抑制にも該当しないが、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5274,
+    "usage": {
+      "prompt": 876,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 1018
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-458",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は免疫機能の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5199,
+    "usage": {
+      "prompt": 770,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 908
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-459",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究であり、神経行動評価を含んでいる"
+    ],
+    "durationMs": 6473,
+    "usage": {
+      "prompt": 997,
+      "completion": 184,
+      "reasoning": 0,
+      "total": 1181
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-460",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ビタミンA投与ラットにおける脂質取り込みの研究である"
+    ],
+    "durationMs": 6814,
+    "usage": {
+      "prompt": 480,
+      "completion": 193,
+      "reasoning": 0,
+      "total": 673
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-461",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（FSLラット）を用いたin vivo研究であり、対象が明確に動物である"
+    ],
+    "durationMs": 5514,
+    "usage": {
+      "prompt": 649,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 803
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-462",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録から、本研究は心臓および血管のATP感受性カリウムチャネルを対象としており、うつ病（depression）のin vivo動物モデルに関する研究ではない。また、「depression」が言及されておらず、呼吸性または心臓性の抑制（depression）を指す可能性も確認できないが、うつ病モデルの研究ではないことが明確である。"
+    ],
+    "durationMs": 4438,
+    "usage": {
+      "prompt": 457,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 581
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-463",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指している"
+    ],
+    "durationMs": 5091,
+    "usage": {
+      "prompt": 515,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 660
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-464",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指しており、うつ病モデルではない",
+      "対象が牛の生産効率に関するもので、動物うつ病モデルの研究ではない"
+    ],
+    "durationMs": 4318,
+    "usage": {
+      "prompt": 550,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 673
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-465",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や代謝抑制など精神疾患としてのうつ病を指していない",
+      "研究対象は腎臓手術後の代謝活性であり、うつ病モデルではない",
+      "対象はラットだが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5417,
+    "usage": {
+      "prompt": 575,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 716
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-466",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト以外の動物（リスザル）ではあるが、うつ病のin vivoモデルとして明示されておらず、分離ストレスによる生理的変化を観察した研究であり、うつ病モデルの確立や評価が目的ではない。また、抄録内で「major depression」と言及されているが、これはヒトにおける臨床研究との比較であり、動物モデルとしてのうつ病を直接的に扱っていない。"
+    ],
+    "durationMs": 6512,
+    "usage": {
+      "prompt": 590,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 776
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-467",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、リチウムの作用機序に関する基礎生化学研究である"
+    ],
+    "durationMs": 4219,
+    "usage": {
+      "prompt": 661,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 770
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-468",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく羊であるが、うつ病の動物モデルに関する研究ではなく、ACTHによる高血圧とバロレフレックスの研究である。「depression」がうつ病を指しておらず、呼吸抑制や心機能抑制などの文脈にも該当しないが、うつ病モデルではないため除外される。"
+    ],
+    "durationMs": 6814,
+    "usage": {
+      "prompt": 577,
+      "completion": 203,
+      "reasoning": 0,
+      "total": 780
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-469",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または心臓性の機能低下を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4310,
+    "usage": {
+      "prompt": 799,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 905
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-470",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト細胞株（SN-48、COS-7）を用いたin vitro実験であり、in vivo動物モデルではない"
+    ],
+    "durationMs": 5823,
+    "usage": {
+      "prompt": 783,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 953
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-471",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅球切除ラットを用いたうつ病の動物モデルに関する研究であり、in vivo動物実験であるため"
+    ],
+    "durationMs": 5440,
+    "usage": {
+      "prompt": 618,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 776
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-472",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3836,
+    "usage": {
+      "prompt": 804,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 905
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-473",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "研究対象が子宮タンパク質のエストロゲン誘導であり、うつ病とは無関係"
+    ],
+    "durationMs": 6790,
+    "usage": {
+      "prompt": 552,
+      "completion": 190,
+      "reasoning": 0,
+      "total": 742
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-474",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、脳切片を用いた神経生理学的実験である"
+    ],
+    "durationMs": 4159,
+    "usage": {
+      "prompt": 758,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-475",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "抄録がなく、タイトルから動物モデルを用いたうつ病研究かどうか判断できないため、感度を優先して仮に含める可能性がある"
+    ],
+    "durationMs": 2546,
+    "usage": {
+      "prompt": 402,
+      "completion": 60,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-476",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（マウス）を用いた研究であり、うつ病様行動を評価している"
+    ],
+    "durationMs": 7172,
+    "usage": {
+      "prompt": 734,
+      "completion": 212,
+      "reasoning": 0,
+      "total": 946
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-477",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたin vivo実験で、レセルピン誘発性運動抑制（うつ病モデル）を評価しており、動物モデルにおけるうつ病関連研究である"
+    ],
+    "durationMs": 5112,
+    "usage": {
+      "prompt": 549,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 683
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-478",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫機能の抑制（lymphocyte blastogenesisの抑制）を指しており、うつ病モデルではない",
+      "対象が犬でありヒトではないが、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4768,
+    "usage": {
+      "prompt": 483,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 611
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-479",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、心機能の抑制（aortic flowのdepression）を指している",
+      "対象はラット心臓の虚血・再灌流モデルであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4815,
+    "usage": {
+      "prompt": 862,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 994
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-480",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制など精神疾患としてのうつ病を指していない",
+      "対象がイヌであり動物実験だが、うつ病モデルではない",
+      "研究目的が心血管系への麻酔薬の影響であり、うつ病関連ではない"
+    ],
+    "durationMs": 5374,
+    "usage": {
+      "prompt": 618,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 762
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-481",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が摂食反応の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3865,
+    "usage": {
+      "prompt": 772,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 869
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-482",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心臓抑制などの生理的抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3859,
+    "usage": {
+      "prompt": 579,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 681
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-483",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や循環抑制などを指す可能性があるが、本抄録では「symptoms of depression」として一般的な症状として記載されており、うつ病（depression）の動物モデルを対象とした研究ではない。また、研究目的は摂食行動に関与する視床下部ニューロペプチドへのアフラトキシンB1の影響であり、うつ病モデルではない。"
+    ],
+    "durationMs": 6836,
+    "usage": {
+      "prompt": 873,
+      "completion": 192,
+      "reasoning": 0,
+      "total": 1065
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-484",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋抑制（myocardial depression）を指しており、うつ病モデルではない",
+      "研究対象は糖尿病性心不全のラットモデルであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6183,
+    "usage": {
+      "prompt": 864,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 1029
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-485",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的現象である長期抑圧（long-term depression）を指しており、うつ病（depression as a mood disorder）の動物モデルではない"
+    ],
+    "durationMs": 5445,
+    "usage": {
+      "prompt": 665,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 823
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-486",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物実験ではなく、理論的・概念的議論に焦点を当てているため",
+      "うつ病のin vivoモデルに関する実験的データが含まれていない"
+    ],
+    "durationMs": 5846,
+    "usage": {
+      "prompt": 736,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 891
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-487",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを対象とした研究であり、in vivo（ラット）を使用しているため"
+    ],
+    "durationMs": 6075,
+    "usage": {
+      "prompt": 808,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 980
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-488",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経細胞の抑制（神経生理学的抑制）を指しており、うつ病モデルではない",
+      "対象が猫の視索上核神経細胞で、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 5098,
+    "usage": {
+      "prompt": 527,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 664
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-489",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "抄録中に「depression」が動物行動の一部として言及されているが、それがうつ病モデルを用いた研究かどうか、または単なる関連行動の一覧であるかが明確でないため、全文確認が必要"
+    ],
+    "durationMs": 4941,
+    "usage": {
+      "prompt": 653,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 781
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-490",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がイヌの肺動脈であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "「depression」が呼吸抑制や心機能抑制などを指している可能性があるが、本抄録ではそもそも「depression」という語が使用されていない",
+      "うつ病に関連する行動や神経生物学的指標の評価が含まれていない"
+    ],
+    "durationMs": 4368,
+    "usage": {
+      "prompt": 780,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-491",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "抄録に「Porsolt's behavioural despair test」と記載があり、これはうつ病のin vivo動物モデルで広く用いられる行動試験であるため、動物実験であると判断できる"
+    ],
+    "durationMs": 4559,
+    "usage": {
+      "prompt": 548,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 675
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-492",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「spreading depression」は神経生理学的現象であり、うつ病（depression）の動物モデルではない",
+      "呼吸性または心臓性の「depression」ではないが、精神疾患としてのうつ病の研究でもない"
+    ],
+    "durationMs": 5687,
+    "usage": {
+      "prompt": 608,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 769
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-493",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "強制泳ぎ試験を用いたマウスを対象としたうつ病のin vivo動物実験であり、人間の研究ではない"
+    ],
+    "durationMs": 7321,
+    "usage": {
+      "prompt": 708,
+      "completion": 209,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-494",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、長期抑圧（long-term depression: LTD）という神経科学用語として使用されており、うつ病のin vivo動物モデルに関する研究ではない。",
+      "研究は脳スライス（in vitro）を用いており、in vivoモデルではない。"
+    ],
+    "durationMs": 6647,
+    "usage": {
+      "prompt": 773,
+      "completion": 194,
+      "reasoning": 0,
+      "total": 967
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-495",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「Depression」がうつ病ではなく、葉酸活性の抑制（抑制・低下）を指している可能性が高い",
+      "動物実験かどうかが判断できないが、タイトルからうつ病モデルの研究とは考えにくく、対象外の可能性が高い"
+    ],
+    "durationMs": 4647,
+    "usage": {
+      "prompt": 400,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 530
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-496",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病の動物モデル（強制泳泳試験）に関する研究であり、ヒト研究ではなく、呼吸抑圧などの他の意味での「depression」ではない。"
+    ],
+    "durationMs": 8071,
+    "usage": {
+      "prompt": 903,
+      "completion": 238,
+      "reasoning": 0,
+      "total": 1141
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-497",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、副腎の5α-還元酵素活性とコルチコステロン産生に焦点を当てた研究である可能性が高い"
+    ],
+    "durationMs": 4403,
+    "usage": {
+      "prompt": 412,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 531
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-498",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病の動物モデル（UCMS）に関する研究であり、in vivo動物実験であるため"
+    ],
+    "durationMs": 7186,
+    "usage": {
+      "prompt": 1128,
+      "completion": 215,
+      "reasoning": 0,
+      "total": 1343
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-499",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなくin vitro（脳スライス）であり、うつ病モデルではない"
+    ],
+    "durationMs": 4242,
+    "usage": {
+      "prompt": 750,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 857
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-500",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がウシの解剖学的異常に関する研究であり、うつ病のin vivo動物モデルではない。「depression」という語は身体の陥没を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5051,
+    "usage": {
+      "prompt": 704,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 839
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-501",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ラット子宮平滑筋の弛緩作用を調べた研究である"
+    ],
+    "durationMs": 5290,
+    "usage": {
+      "prompt": 611,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 752
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-502",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、くる病ラットにおけるヒドロキシプロリン尿の研究である"
+    ],
+    "durationMs": 3791,
+    "usage": {
+      "prompt": 411,
+      "completion": 94,
+      "reasoning": 0,
+      "total": 505
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-503",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、血小板凝集およびエイコサノイド代謝に関する研究である"
+    ],
+    "durationMs": 4436,
+    "usage": {
+      "prompt": 567,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 684
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-504",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」でもない"
+    ],
+    "durationMs": 6247,
+    "usage": {
+      "prompt": 728,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 903
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-505",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」の明確な記載がなく、動物実験である可能性はあるが、うつ病モデルかどうか判断できないため"
+    ],
+    "durationMs": 2967,
+    "usage": {
+      "prompt": 406,
+      "completion": 67,
+      "reasoning": 0,
+      "total": 473
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-506",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が生体外（in vitro）のラット線維芽細胞であり、in vivoモデルではない"
+    ],
+    "durationMs": 3927,
+    "usage": {
+      "prompt": 1130,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 1236
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-507",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はシナプス可塑性における長期抑圧（long-term depression, LTD）を指しており、うつ病（depression as a mood disorder）の動物モデルではない"
+    ],
+    "durationMs": 5776,
+    "usage": {
+      "prompt": 830,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 993
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-508",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない可能性が高い",
+      "タイトルに「depression」の語が含まれておらず、うつ病との関連が不明"
+    ],
+    "durationMs": 2446,
+    "usage": {
+      "prompt": 411,
+      "completion": 60,
+      "reasoning": 0,
+      "total": 471
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-509",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトであり、動物モデルではないため除外"
+    ],
+    "durationMs": 3881,
+    "usage": {
+      "prompt": 631,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 730
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-510",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動の動物モデルに関する研究であり、in vivoのうつ病モデル研究であるため"
+    ],
+    "durationMs": 5714,
+    "usage": {
+      "prompt": 967,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 1130
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-511",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、視覚遮断による視覚誘発電位の変化を調べた研究である。「depression」は抑制（生理学的抑制）を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 4443,
+    "usage": {
+      "prompt": 598,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 721
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-512",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または循環性の抑制（例：depressor sites）を指しており、うつ病モデルではない",
+      "対象は猫の生理学的実験であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5119,
+    "usage": {
+      "prompt": 852,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 991
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-513",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（女性）であり、動物モデルではないため除外"
+    ],
+    "durationMs": 5391,
+    "usage": {
+      "prompt": 633,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 788
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-514",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depressive effects」は神経活動の抑制を指しており、うつ病モデルではない。うつ病（depression）に関する動物モデルの研究ではない。"
+    ],
+    "durationMs": 5305,
+    "usage": {
+      "prompt": 771,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 894
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-515",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "in vivoのうつ病モデルを用いておらず、C6グリオーマ細胞を用いたin vitro研究である"
+    ],
+    "durationMs": 4027,
+    "usage": {
+      "prompt": 731,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 841
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-516",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（小児）であり、動物モデルではないため"
+    ],
+    "durationMs": 4832,
+    "usage": {
+      "prompt": 973,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 1102
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-517",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は心機能低下（心臓のうつ）を指しており、うつ病モデルではない",
+      "対象は心筋梗塞後の心リモデリングに関する動物実験であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5621,
+    "usage": {
+      "prompt": 835,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 990
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-518",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病のin vivoモデルに関する動物実験であり、ヒト研究ではない。強制水泳試験（FST）を用いて抗うつ薬の行動効果を評価している。"
+    ],
+    "durationMs": 6392,
+    "usage": {
+      "prompt": 649,
+      "completion": 187,
+      "reasoning": 0,
+      "total": 836
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-519",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が精神疾患としてのうつ病ではなく、一般的な症状（元気消失）を指している可能性が高い",
+      "対象が馬であり動物研究ではあるが、うつ病のin vivoモデルではない",
+      "呼吸抑制や心機能抑制などの臓器抑制を指すものでもないが、精神疾患モデルの研究ではない"
+    ],
+    "durationMs": 5115,
+    "usage": {
+      "prompt": 488,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 631
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-520",
+    "label_included": 0,
+    "include_probability": 0.7,
+    "reasons": [
+      "タイトルにラット（in vivo動物モデル）が使用されていることと、イミプラミン（抗うつ薬）が含まれており、うつ病モデルに関連する可能性があるが、抄録がなく明確な評価ができない"
+    ],
+    "durationMs": 5478,
+    "usage": {
+      "prompt": 413,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 571
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-521",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いた経口薬物動態試験が実施されており、うつ病治療薬の動物モデル研究に該当する可能性があるため"
+    ],
+    "durationMs": 4387,
+    "usage": {
+      "prompt": 790,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 908
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-522",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物実験ではあるが、研究テーマは心機能への造影剤の影響であり、うつ病（depression）のin vivoモデルではない。文中の'depression'は心機能低下（cardiac depression）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5229,
+    "usage": {
+      "prompt": 589,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 736
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-523",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」の明確な記載がなく、自己切断行動の神経薬理学的アプローチについて述べているが、うつ病のin vivoモデルに関する記述が確認できない",
+      "抄録が存在しないため、研究内容の詳細が不明であり、うつ病モデル動物研究かどうか判断できないが、タイトルからうつ病関連の可能性は低い"
+    ],
+    "durationMs": 4395,
+    "usage": {
+      "prompt": 400,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 521
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-524",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は脳のグルコース取り込みの低下を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4200,
+    "usage": {
+      "prompt": 744,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 861
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-525",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4215,
+    "usage": {
+      "prompt": 736,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 848
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-526",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅球摘出マウスを用いたうつ病モデルに関する動物実験であり、抗うつ薬の効果や脳内セロトニン系の変化を評価している。人間の研究ではなく、呼吸抑制などの他の「depression」との混同もない。"
+    ],
+    "durationMs": 5824,
+    "usage": {
+      "prompt": 610,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 774
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-527",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」が含まれるが、動物モデルに関する記述がなく、ヒト研究か否か不明であるため、感度を優先して含める可能性を考慮"
+    ],
+    "durationMs": 4055,
+    "usage": {
+      "prompt": 395,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 503
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-528",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能抑制ではなく生化学的活性の低下を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 4146,
+    "usage": {
+      "prompt": 649,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 758
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-529",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivo動物実験であり、うつ病に関連する薬理学的介入（抗うつ薬）を含んでいるため"
+    ],
+    "durationMs": 6692,
+    "usage": {
+      "prompt": 836,
+      "completion": 195,
+      "reasoning": 0,
+      "total": 1031
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-530",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "血小板とコラーゲンの反応に関する研究であり、対象がうつ病のin vivoモデルとは無関係"
+    ],
+    "durationMs": 3410,
+    "usage": {
+      "prompt": 400,
+      "completion": 87,
+      "reasoning": 0,
+      "total": 487
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-531",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、動物実験の目的がうつ病モデルかどうか不明である。抄録が存在しないため判断材料が不足しているが、タイトルからうつ病研究とは直接関連しないと推測される。"
+    ],
+    "durationMs": 3691,
+    "usage": {
+      "prompt": 421,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 517
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-532",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4397,
+    "usage": {
+      "prompt": 736,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 846
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-533",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は心機能低下（cardiac depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5471,
+    "usage": {
+      "prompt": 805,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 959
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-534",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3753,
+    "usage": {
+      "prompt": 1101,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 1192
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-535",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する明確な記載がなく、動物実験かどうか判断できないため、感度を優先して中立的確率を付与"
+    ],
+    "durationMs": 2842,
+    "usage": {
+      "prompt": 406,
+      "completion": 73,
+      "reasoning": 0,
+      "total": 479
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-536",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "抄録が存在せず、研究内容の判断ができないが、タイトルから神経生理学的研究と推測され、うつ病モデルとは無関係と判断される"
+    ],
+    "durationMs": 3823,
+    "usage": {
+      "prompt": 403,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 501
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-537",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」でもない"
+    ],
+    "durationMs": 5895,
+    "usage": {
+      "prompt": 782,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 956
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-538",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動のin vivo研究であり、対象とする動物モデルの研究である"
+    ],
+    "durationMs": 5212,
+    "usage": {
+      "prompt": 704,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 851
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-539",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット脳切片を用いたin vitro実験であり、in vivoモデルではない。また、「depression」はLTPの抑制を指しており、うつ病モデルではない。"
+    ],
+    "durationMs": 6242,
+    "usage": {
+      "prompt": 693,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 867
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-540",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、魚類の卵母細胞の成熟に関する研究である"
+    ],
+    "durationMs": 4485,
+    "usage": {
+      "prompt": 441,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 555
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-541",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経生理学的な抑制（EPSPの振幅減少）を指しており、うつ病モデルではない",
+      "in vitro 脳幹脊髄標本を用いた実験であり、in vivo うつ病モデルではない"
+    ],
+    "durationMs": 8816,
+    "usage": {
+      "prompt": 618,
+      "completion": 268,
+      "reasoning": 0,
+      "total": 886
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-542",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関する動物実験であり、うつ病行動の評価（テールサスペンション試験）を行っている"
+    ],
+    "durationMs": 6472,
+    "usage": {
+      "prompt": 658,
+      "completion": 181,
+      "reasoning": 0,
+      "total": 839
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-543",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "アルビノマウスを用いたうつ病モデルに関するin vivo動物実験であり、ヒト研究ではない。うつ病は呼吸抑制や心機能抑制などを指しておらず、行動試験（テールサスペンション試験）で抗うつ効果を評価している。"
+    ],
+    "durationMs": 6720,
+    "usage": {
+      "prompt": 835,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 1032
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-544",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、うつ病を指しているか不明だが、本研究は高血圧ラットの血管内皮依存性弛緩の低下（depressed relaxation）を扱っており、精神疾患としてのうつ病の動物モデルではない。"
+    ],
+    "durationMs": 5090,
+    "usage": {
+      "prompt": 791,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 935
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-545",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2494,
+    "usage": {
+      "prompt": 408,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 461
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-546",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い",
+      "タイトルから呼吸抑制や心臓抑制などの「depression」との関連も見られないが、対象が冠血管拡張であり、うつ病とは無関係と判断される"
+    ],
+    "durationMs": 3787,
+    "usage": {
+      "prompt": 402,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 498
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-547",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が筋肉の活動電位の抑制（生理学的抑制）を指しており、うつ病モデルではない",
+      "対象がカエルおよびウサギの神経筋・交感神経系であり、うつ病のin vivoモデルではない",
+      "うつ病（depression）が精神疾患として扱われていない"
+    ],
+    "durationMs": 5653,
+    "usage": {
+      "prompt": 563,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 726
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-548",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、シナプス可塑性の一種である長期抑圧（long-term depression, LTD）を指している",
+      "対象はうつ病のin vivoモデルではなく、ストレスによる記銘障害のメカニズムに関する動物研究"
+    ],
+    "durationMs": 6878,
+    "usage": {
+      "prompt": 579,
+      "completion": 195,
+      "reasoning": 0,
+      "total": 774
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-549",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経伝達の抑制を指しており、うつ病モデルではない",
+      "対象はハトだが、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4333,
+    "usage": {
+      "prompt": 532,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 651
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-550",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "非ヒト霊長類（シノモンガス猿）を用いたうつ病のin vivoモデルに関する研究であり、対象が動物実験であるため"
+    ],
+    "durationMs": 4820,
+    "usage": {
+      "prompt": 849,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 974
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-551",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、神経伝達受容体の分子メカニズムに焦点を当てている",
+      "「depression」が「電流の抑制」を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 4870,
+    "usage": {
+      "prompt": 608,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 742
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-552",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がアルコール性肝障害に関する研究であり、うつ病のin vivoモデルではない",
+      "「depression」が呼吸抑制（respiratory depression）として言及されており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 4642,
+    "usage": {
+      "prompt": 725,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-553",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸器や心臓の抑制ではなく皮膚のDNA合成の抑制を指しており、うつ病の動物モデルの研究ではない",
+      "対象がハゲネズミ（in vivo動物モデル）ではあるが、うつ病とは無関係な皮膚反応の研究である"
+    ],
+    "durationMs": 5467,
+    "usage": {
+      "prompt": 538,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 688
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-554",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いた強制水泳試験（FST）によるうつ病モデルのin vivo研究であり、ヒト研究ではない"
+    ],
+    "durationMs": 4798,
+    "usage": {
+      "prompt": 617,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 736
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-555",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、抗うつ薬（フルオキセチン）の性的副作用を調べた動物実験である。うつ病そのものやその動物モデルを対象としていない。"
+    ],
+    "durationMs": 5099,
+    "usage": {
+      "prompt": 714,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-556",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、動物実験であることが明確"
+    ],
+    "durationMs": 5853,
+    "usage": {
+      "prompt": 717,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 879
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-557",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的現象（ペアパルス抑圧）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3878,
+    "usage": {
+      "prompt": 1067,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 1169
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-558",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸機能の低下（respiratory depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4057,
+    "usage": {
+      "prompt": 750,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 856
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-559",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルからうつ病の動物モデルに関する研究であることを示す情報が全く得られない",
+      "対象が神経筋遮断作用であり、うつ病とは無関係と判断される"
+    ],
+    "durationMs": 4884,
+    "usage": {
+      "prompt": 420,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 557
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-560",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病や動物モデルに関する記述がなく、生化学的実験（牛膵臓由来タンパク質の酸性pH下での限定的プロテオリシス）を示唆しているため、対象外と判断される"
+    ],
+    "durationMs": 5206,
+    "usage": {
+      "prompt": 406,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 554
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-561",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、乳腺腫瘍とプロラクチン受容体に関する研究である"
+    ],
+    "durationMs": 4572,
+    "usage": {
+      "prompt": 614,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 731
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-562",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が不安障害（anxiety）であり、うつ病（depression）のin vivoモデルではない"
+    ],
+    "durationMs": 5551,
+    "usage": {
+      "prompt": 848,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 1001
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-563",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2599,
+    "usage": {
+      "prompt": 402,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 457
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-564",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」に関連する用語が含まれておらず、肝臓への影響を調べた動物実験であるが、うつ病モデルの研究ではないと判断される"
+    ],
+    "durationMs": 3229,
+    "usage": {
+      "prompt": 402,
+      "completion": 77,
+      "reasoning": 0,
+      "total": 479
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-565",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語は呼吸抑制や心機能抑制などを指す文脈で使われており、うつ病（depression）の動物モデルに関する研究ではない。また、抄録全体でうつ病やその行動モデルに関する記述が全くない。"
+    ],
+    "durationMs": 5176,
+    "usage": {
+      "prompt": 787,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 933
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-566",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病のin vivo動物モデルに関する記述がなく、化合物の合成に関するものと推測されるため"
+    ],
+    "durationMs": 2381,
+    "usage": {
+      "prompt": 420,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 475
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-567",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」や動物モデルに関する記述がなく、腎臓のイオン輸送に関する研究とみられるため"
+    ],
+    "durationMs": 2600,
+    "usage": {
+      "prompt": 419,
+      "completion": 60,
+      "reasoning": 0,
+      "total": 479
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-568",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "抄録に動物実験の記載がなく、in vivoモデルの使用が不明であるため、感度重視の原則に基づき含める可能性を考慮"
+    ],
+    "durationMs": 4030,
+    "usage": {
+      "prompt": 538,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 645
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-569",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトのうつ病メカニズムの動物モデルではなく、猫を用いた睡眠遮断によるセロトニン神経活動の変化を調べた研究であり、うつ病のin vivoモデルとして明示されていない。うつ病の動物モデルではなく、抗うつ作用の機序解明のための生理学的研究である可能性が高い。"
+    ],
+    "durationMs": 8690,
+    "usage": {
+      "prompt": 796,
+      "completion": 240,
+      "reasoning": 0,
+      "total": 1036
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-570",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が含まれていない。また、研究対象はクモであり、うつ病のin vivoモデルに関する動物研究ではない。"
+    ],
+    "durationMs": 3165,
+    "usage": {
+      "prompt": 866,
+      "completion": 62,
+      "reasoning": 0,
+      "total": 928
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-571",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3815,
+    "usage": {
+      "prompt": 716,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 817
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-572",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が生体外の皮膚スライスであり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3901,
+    "usage": {
+      "prompt": 692,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 798
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-573",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は脚の動きにおける「下制（depression of the trochantero-femur）」を指しており、うつ病（depression）とは無関係である。対象はカギムシ（stick insect）の運動制御に関する神経生理学的研究であり、うつ病のin vivo動物モデルではない。"
+    ],
+    "durationMs": 5864,
+    "usage": {
+      "prompt": 692,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-574",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病のin vivo動物モデルではなく、心筋のKATPチャネルに関するものであり、「depression」が呼吸抑制や心機能抑制を指す可能性があるが、本抄録では「depression」自体が使用されていない。対象疾患がうつ病ではない。"
+    ],
+    "durationMs": 7946,
+    "usage": {
+      "prompt": 872,
+      "completion": 235,
+      "reasoning": 0,
+      "total": 1107
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-575",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルが肝毒性に関するものであり、うつ病のin vivoモデルに関する記述がない",
+      "抄録が存在せず、うつ病モデルに関する情報を確認できない"
+    ],
+    "durationMs": 4175,
+    "usage": {
+      "prompt": 400,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 513
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-576",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、皮膚がん誘発と免疫応答に関する研究である"
+    ],
+    "durationMs": 4669,
+    "usage": {
+      "prompt": 589,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 706
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-577",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、糞便卵数減少（faecal egg count depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 4419,
+    "usage": {
+      "prompt": 655,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 767
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-578",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "慢性ストレスを加えたラットを用いたうつ病の動物モデルに関する研究であり、in vivoで実施されている"
+    ],
+    "durationMs": 4271,
+    "usage": {
+      "prompt": 770,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 880
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-579",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、モルヒネの生殖能力および免疫状態への影響を調査している"
+    ],
+    "durationMs": 4085,
+    "usage": {
+      "prompt": 494,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 600
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-580",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、造血作用に関する研究である"
+    ],
+    "durationMs": 3770,
+    "usage": {
+      "prompt": 406,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 499
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-581",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢抑制作用（central depressive activity）を指しており、うつ病モデルの動物研究ではないと判断される"
+    ],
+    "durationMs": 4579,
+    "usage": {
+      "prompt": 547,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 674
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-582",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2374,
+    "usage": {
+      "prompt": 419,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 472
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-583",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoうつ病モデルの動物研究ではなく、in vitroの神経細胞実験であることが示唆される",
+      "「depression」がシナプス可塑性における「抑制」を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 6306,
+    "usage": {
+      "prompt": 621,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 806
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-584",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経症状としての抑うつ状態を指しており、うつ病（depression）の動物モデル研究ではない",
+      "研究対象は羊における急性コエヌローシス（寄生虫感染症）であり、うつ病の病態モデルではない"
+    ],
+    "durationMs": 5477,
+    "usage": {
+      "prompt": 906,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 1062
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-585",
+    "label_included": 0,
+    "include_probability": 0.7,
+    "reasons": [
+      "タイトルに「thymoleptic effect（気分改善作用）」と「central serotoninergic processes（中枢セロトニン作動系）」が含まれており、うつ病の動物モデル研究の可能性があるが、抄録がなく、対象が動物か人間か明確でないため"
+    ],
+    "durationMs": 5069,
+    "usage": {
+      "prompt": 408,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 548
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-586",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はうつ病ではなく、小脳プルキンエ細胞におけるシナプス伝達の抑制（long-term depression: LTD）を指している",
+      "対象は動物モデルのうつ病ではなく、神経生理学的現象の研究である"
+    ],
+    "durationMs": 6269,
+    "usage": {
+      "prompt": 736,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 914
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-587",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や心臓の機能低下（心筋機能の抑制）を指しており、うつ病モデルではない",
+      "対象はウサギ心臓の虚血・再灌流モデルであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6225,
+    "usage": {
+      "prompt": 659,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 837
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-588",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、腸ホルモンと行動（報酬、不安、気分など）に関するレビューであり、うつ病そのものを対象としていない"
+    ],
+    "durationMs": 4673,
+    "usage": {
+      "prompt": 588,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 709
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-589",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、胎児マウス由来の培養神経細胞を用いたin vitro実験であるため"
+    ],
+    "durationMs": 4192,
+    "usage": {
+      "prompt": 708,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-590",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "タイトルに「depression」の用語が含まれておらず、対象がロブスター神経である"
+    ],
+    "durationMs": 4327,
+    "usage": {
+      "prompt": 402,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 514
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-591",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病に関するin vivo動物モデル研究を含んでおり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではないため"
+    ],
+    "durationMs": 7265,
+    "usage": {
+      "prompt": 785,
+      "completion": 210,
+      "reasoning": 0,
+      "total": 995
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-592",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制（growth depression）を指しており、うつ病モデルではない",
+      "対象がchannel catfishであり、うつ病のin vivoモデル研究ではない"
+    ],
+    "durationMs": 4212,
+    "usage": {
+      "prompt": 707,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 817
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-593",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、有機リン系神経剤中毒によるけいれんおよび神経損傷の研究であるため"
+    ],
+    "durationMs": 4418,
+    "usage": {
+      "prompt": 964,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 1081
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-594",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3985,
+    "usage": {
+      "prompt": 674,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 777
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-595",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はシナプス抑制（synaptic depression）を指しており、うつ病（depression）の動物モデルではない",
+      "対象はラット脳スライスを用いたin vitro実験であり、in vivoモデルではない"
+    ],
+    "durationMs": 6666,
+    "usage": {
+      "prompt": 703,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 894
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-596",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病（depression）に関する記述がなく、腸上皮細胞のブラシ縁に関する生化学的研究であることが明らか"
+    ],
+    "durationMs": 5175,
+    "usage": {
+      "prompt": 422,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 558
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-597",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫機能の抑制（thymus-dependent antibody formationの低下）を指しており、うつ病モデルではない",
+      "研究はマウスを用いているが、うつ病のin vivoモデルに関するものではない"
+    ],
+    "durationMs": 4971,
+    "usage": {
+      "prompt": 615,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 748
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-598",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "学習無力感誘発動物モデルを用いたうつ病のin vivo研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 6248,
+    "usage": {
+      "prompt": 763,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 942
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-599",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2374,
+    "usage": {
+      "prompt": 404,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 455
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-600",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（ラット）を用いた研究であり、行動検査（スクロース消費試験、強制泳泳試験など）でうつ様行動を評価している。対象はヒトではなく、呼吸・循環抑制などの「depression」とは無関係である。"
+    ],
+    "durationMs": 8164,
+    "usage": {
+      "prompt": 786,
+      "completion": 239,
+      "reasoning": 0,
+      "total": 1025
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-601",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、シナプス可塑性における長期抑圧（long-term depression, LTD）を指しており、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4750,
+    "usage": {
+      "prompt": 713,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 834
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-602",
+    "label_included": 1,
+    "include_probability": 0.7,
+    "reasons": [
+      "タイトルに「animal behavior」とあり、うつ病モデル動物研究の可能性があるが、抄録がなく、うつ病への関連が明確でないため"
+    ],
+    "durationMs": 3761,
+    "usage": {
+      "prompt": 405,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 506
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-603",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「inbreeding depression（近交劣勢）」を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3883,
+    "usage": {
+      "prompt": 842,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 946
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-604",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がイカ軸索であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4500,
+    "usage": {
+      "prompt": 803,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-605",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない",
+      "'depression'はリンパ球比の低下を指しており、うつ病ではない"
+    ],
+    "durationMs": 5823,
+    "usage": {
+      "prompt": 682,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 844
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-606",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「抗うつ薬」とあるが、動物実験か人間を対象とした研究か不明であり、抄録がないため判断できない"
+    ],
+    "durationMs": 4022,
+    "usage": {
+      "prompt": 399,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 507
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-607",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、研究対象が避妊作用であり、うつ病のin vivoモデルに関するものではないと判断される"
+    ],
+    "durationMs": 3115,
+    "usage": {
+      "prompt": 415,
+      "completion": 73,
+      "reasoning": 0,
+      "total": 488
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-608",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2616,
+    "usage": {
+      "prompt": 419,
+      "completion": 49,
+      "reasoning": 0,
+      "total": 468
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-609",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経活動の抑制（neuronal depression）を指しており、うつ病（depression）の動物モデルではない",
+      "呼吸抑制や心機能抑制と同様に、神経生理学的な抑制現象を指していると判断される"
+    ],
+    "durationMs": 6807,
+    "usage": {
+      "prompt": 651,
+      "completion": 187,
+      "reasoning": 0,
+      "total": 838
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-610",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指す文脈ではなく、酵素分泌活性の「抑制（depression）」を意味しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4301,
+    "usage": {
+      "prompt": 579,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 697
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-611",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットのうつ病モデルを用いた動物実験が含まれているため"
+    ],
+    "durationMs": 4073,
+    "usage": {
+      "prompt": 601,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 702
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-612",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4498,
+    "usage": {
+      "prompt": 599,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 697
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-613",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない。タイトルおよび抄録に「うつ病」または関連する言及がなく、代謝酵素への薬物影響を調べた研究と推定される。"
+    ],
+    "durationMs": 3269,
+    "usage": {
+      "prompt": 408,
+      "completion": 73,
+      "reasoning": 0,
+      "total": 481
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-614",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸バーストの抑制を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 3990,
+    "usage": {
+      "prompt": 608,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 714
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-615",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制（growth depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3464,
+    "usage": {
+      "prompt": 797,
+      "completion": 90,
+      "reasoning": 0,
+      "total": 887
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-616",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "強制泳ぐ試験（FST）というin vivoうつ病モデルが使用されていると明記されており、動物実験であると判断できる"
+    ],
+    "durationMs": 4284,
+    "usage": {
+      "prompt": 641,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 758
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-617",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制などの生理的抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4882,
+    "usage": {
+      "prompt": 849,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 977
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-618",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（マウスおよびラット）を用いた研究であり、行動ベースの抗うつ効果評価を行っている"
+    ],
+    "durationMs": 7077,
+    "usage": {
+      "prompt": 787,
+      "completion": 207,
+      "reasoning": 0,
+      "total": 994
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-619",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、麻酔下の犬を用いた脳皮質の反応性に関する実験である。うつ病（depression）に関する研究ではない。"
+    ],
+    "durationMs": 5563,
+    "usage": {
+      "prompt": 612,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 744
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-620",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoうつ病モデルではなく、in vitroでの赤血球造血に関する研究である"
+    ],
+    "durationMs": 4914,
+    "usage": {
+      "prompt": 669,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 806
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-621",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、副腎摘出マウスにおけるエリスロポエーシスの感受性に関する研究である"
+    ],
+    "durationMs": 4776,
+    "usage": {
+      "prompt": 421,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 553
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-622",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデル（慢性社会的敗北ストレス）に関するin vivo動物実験であり、対象がヒトでなく、呼吸・循環器系の抑制を指すものでもない"
+    ],
+    "durationMs": 4601,
+    "usage": {
+      "prompt": 541,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 662
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-623",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が自発的活動の抑制（中枢神経系におけるニコチンの作用）を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4543,
+    "usage": {
+      "prompt": 782,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 909
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-624",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はリンパ球のホーミング能の低下を指しており、うつ病（depression）の動物モデルではない",
+      "対象はマウスリンパ球のin vivo移動であり、うつ病の病理や行動評価に関する研究ではない",
+      "呼吸抑制や心機能抑制などではないが、精神疾患としてのうつ病とも無関係"
+    ],
+    "durationMs": 6012,
+    "usage": {
+      "prompt": 744,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 919
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-625",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病のin vivo動物モデルではなく、未熟ラットの胃酸分泌に関するものである",
+      "「depression」は本研究では「抑制（depressed the maximum secretory response）」という生理的抑制を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 6875,
+    "usage": {
+      "prompt": 958,
+      "completion": 200,
+      "reasoning": 0,
+      "total": 1158
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-626",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、プロラクチン分泌に関する研究である"
+    ],
+    "durationMs": 6521,
+    "usage": {
+      "prompt": 578,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 757
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-627",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関するin vivo動物実験であり、ヒト研究ではなく、呼吸・循環器系の抑制を意味する「depression」ではない"
+    ],
+    "durationMs": 5551,
+    "usage": {
+      "prompt": 811,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 972
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-628",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、視覚皮質の発達とシナプス活動の伝達に関する神経生理学的研究である"
+    ],
+    "durationMs": 2660,
+    "usage": {
+      "prompt": 618,
+      "completion": 64,
+      "reasoning": 0,
+      "total": 682
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-629",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（出生前ストレスラット）を用いたin vivo研究であり、対象がヒトでなく、呼吸・心臓の抑制とは無関係"
+    ],
+    "durationMs": 5654,
+    "usage": {
+      "prompt": 736,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 893
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-630",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、オピオイド誘発性の脊髄での長期増強（LTP）および長期抑制（LTD）に関する神経生理学的研究であり、精神疾患としてのうつ病のin vivo動物モデルを対象としていない。また、「depression」という語は本抄録内で「long-term depression（LTD）」という神経生理学的現象を指しており、精神疾患のうつ病とは無関係である。"
+    ],
+    "durationMs": 6727,
+    "usage": {
+      "prompt": 796,
+      "completion": 188,
+      "reasoning": 0,
+      "total": 984
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-631",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなくin vitro試験であり、うつ病モデルではない"
+    ],
+    "durationMs": 4562,
+    "usage": {
+      "prompt": 722,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 837
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-632",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4062,
+    "usage": {
+      "prompt": 822,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 927
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-633",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓の収縮抑制（negative inotropic effect）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 6534,
+    "usage": {
+      "prompt": 870,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 1041
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-634",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病関連のin vivo動物モデル研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」でもない"
+    ],
+    "durationMs": 5407,
+    "usage": {
+      "prompt": 849,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 995
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-635",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、ラット初代肝細胞培養を用いた肝毒性の研究である"
+    ],
+    "durationMs": 5656,
+    "usage": {
+      "prompt": 714,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 876
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-636",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたin vivo動物実験であり、「行動性抑うつ（behavioral depression）」がうつ病モデルとして評価されているため"
+    ],
+    "durationMs": 5276,
+    "usage": {
+      "prompt": 484,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 628
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-637",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器系の機能低下（ATPase活性の抑制）を指しており、うつ病モデルではない",
+      "対象はラットの肺組織であり、うつ病のin vivoモデルではない",
+      "うつ病（depression）に関する動物モデルの研究ではない"
+    ],
+    "durationMs": 4942,
+    "usage": {
+      "prompt": 475,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 610
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-638",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivo実験であり、行動の「抑制」がうつ病様行動として評価されている",
+      "「depression」は呼吸や心機能の抑制ではなく、社会的探索行動の低下といううつ病関連行動を指している"
+    ],
+    "durationMs": 6418,
+    "usage": {
+      "prompt": 591,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 776
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-639",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから、対象がウサギの心房（in vitro）であり、うつ病モデルのin vivo動物研究ではないと判断される",
+      "「depression」が含まれておらず、呼吸抑制や心機能抑制などに関する研究の可能性があるが、うつ病とは無関係"
+    ],
+    "durationMs": 4888,
+    "usage": {
+      "prompt": 413,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 550
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-640",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経科学における長期抑圧（long-term depression, LTD）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5586,
+    "usage": {
+      "prompt": 783,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 926
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-641",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は気道粘液速度の低下を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4674,
+    "usage": {
+      "prompt": 837,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 941
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-642",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない。研究対象はプロスタグランジンと非ステロイド性抗炎症薬の相互作用であり、うつ病との関連は示されていない。"
+    ],
+    "durationMs": 3247,
+    "usage": {
+      "prompt": 550,
+      "completion": 79,
+      "reasoning": 0,
+      "total": 629
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-643",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（ラット）を用いたin vivo研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 6334,
+    "usage": {
+      "prompt": 746,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 920
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-644",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（in vivo動物モデル）であり、うつ病様行動を評価しているため"
+    ],
+    "durationMs": 6329,
+    "usage": {
+      "prompt": 705,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 880
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-645",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 6818,
+    "usage": {
+      "prompt": 680,
+      "completion": 196,
+      "reasoning": 0,
+      "total": 876
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-646",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や関連する動物モデルの記載がなく、避妊作用に関する研究であると推定されるため"
+    ],
+    "durationMs": 3687,
+    "usage": {
+      "prompt": 400,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 459
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-647",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する動物研究ではない",
+      "抄録にうつ病や動物モデルに関する記述が全くない"
+    ],
+    "durationMs": 2364,
+    "usage": {
+      "prompt": 558,
+      "completion": 54,
+      "reasoning": 0,
+      "total": 612
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-648",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経活動の抑制（respiratory depressionなどと同様の生理的抑制）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4399,
+    "usage": {
+      "prompt": 736,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 851
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-649",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が植物（オオムギ）であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "「depression」はマンガン濃度の低下を指しており、精神疾患のうつ病とは無関係"
+    ],
+    "durationMs": 4707,
+    "usage": {
+      "prompt": 751,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 879
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-650",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「inbreeding depression」はうつ病モデルではなく、近交劣勢を指しており、動物うつ病モデルの研究ではない"
+    ],
+    "durationMs": 4102,
+    "usage": {
+      "prompt": 548,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 649
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-651",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が線虫と松の苗木に関する研究であり、うつ病のin vivo動物モデルを含まない"
+    ],
+    "durationMs": 2805,
+    "usage": {
+      "prompt": 694,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 749
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-652",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が脳モノオキシゲナーゼ系酵素活性の低下（抑制）を指しており、うつ病モデルではない",
+      "対象はくも膜下出血のラットモデルであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6147,
+    "usage": {
+      "prompt": 571,
+      "completion": 180,
+      "reasoning": 0,
+      "total": 751
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-653",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がインフルエンザウイルスの複製に関するin vitro細胞実験であり、うつ病のin vivo動物モデルを対象としていない"
+    ],
+    "durationMs": 6874,
+    "usage": {
+      "prompt": 564,
+      "completion": 193,
+      "reasoning": 0,
+      "total": 757
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-654",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫応答の抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3922,
+    "usage": {
+      "prompt": 505,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 605
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-655",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、カルシトニンの低カルシウム血症および食欲抑制効果を調べた研究である"
+    ],
+    "durationMs": 5579,
+    "usage": {
+      "prompt": 605,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 765
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-656",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく犬であるが、うつ病の動物モデルに関する研究ではなく、内毒素ショックにおけるノルエピネフリン濃度の変化を調べたものである"
+    ],
+    "durationMs": 9279,
+    "usage": {
+      "prompt": 605,
+      "completion": 209,
+      "reasoning": 0,
+      "total": 814
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-657",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がウシ胎児および成体のリンパ球の増殖反応に関する研究であり、うつ病のin vivo動物モデルを対象としていない。また、「depression」は細胞増殖の抑制を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 7962,
+    "usage": {
+      "prompt": 766,
+      "completion": 227,
+      "reasoning": 0,
+      "total": 993
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-658",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経活動の抑制を指しており、うつ病モデルではない",
+      "対象が猫の視覚皮質細胞であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "呼吸抑制や心機能抑制などではなくとも、精神疾患としての「うつ病」に関する研究ではない"
+    ],
+    "durationMs": 6575,
+    "usage": {
+      "prompt": 582,
+      "completion": 192,
+      "reasoning": 0,
+      "total": 774
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-659",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、小脳の運動調整に関する研究である"
+    ],
+    "durationMs": 5265,
+    "usage": {
+      "prompt": 643,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 787
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-660",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（ラット）を用いた研究であり、対象とする動物実験に該当する"
+    ],
+    "durationMs": 7614,
+    "usage": {
+      "prompt": 670,
+      "completion": 213,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-661",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能抑制などを指す可能性があるが、本抄録では「colloidopexic capacityのdepression（低下）」を指しており、うつ病（depression）モデルではない。また、うつ病に関する記載は一切ない。"
+    ],
+    "durationMs": 5240,
+    "usage": {
+      "prompt": 512,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 663
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-662",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、BACE1ノックアウトマウスを用いたアルツハイマー病関連のシナプス機能研究である。「depression」はlong-term depression（長期抑圧）を指しており、これは呼吸性や心臓性のdepressionではなくとも、うつ病（depression as a mood disorder）の動物モデルではない。"
+    ],
+    "durationMs": 6006,
+    "usage": {
+      "prompt": 698,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-663",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が長期抑圧（long-term depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない。対象はラットの海馬におけるシナプス可塑性のメカニズムであり、うつ病の病理や治療とは無関係である。"
+    ],
+    "durationMs": 5924,
+    "usage": {
+      "prompt": 713,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-664",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなくin vitro脳スライスを用いた実験であり、うつ病モデルに関する記述がない"
+    ],
+    "durationMs": 4626,
+    "usage": {
+      "prompt": 987,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 1101
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-665",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がウナギの捕食行動に関する動物研究であり、うつ病（depression）の研究ではない。文中の「depression」は解剖学的用語（例: hyoid depression）として使用されており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5037,
+    "usage": {
+      "prompt": 814,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 951
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-666",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルにうつ病や動物モデルに関する明確な記載がなく、抄録が存在しないため、対象が動物実験かどうか判断できない"
+    ],
+    "durationMs": 2890,
+    "usage": {
+      "prompt": 437,
+      "completion": 62,
+      "reasoning": 0,
+      "total": 499
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-667",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルのうつ病研究ではなく、脳由来膜調製物を用いたin vitro実験であるため"
+    ],
+    "durationMs": 5258,
+    "usage": {
+      "prompt": 538,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 649
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-668",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、消化性潰瘍関連の研究である"
+    ],
+    "durationMs": 4576,
+    "usage": {
+      "prompt": 414,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 529
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-669",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（患者）であり、動物モデルではない"
+    ],
+    "durationMs": 5238,
+    "usage": {
+      "prompt": 655,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 786
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-670",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が不安様行動を評価しており、うつ病モデルではない。うつ病関連の行動評価や指標が含まれていない。"
+    ],
+    "durationMs": 4756,
+    "usage": {
+      "prompt": 731,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 861
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-671",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、近交劣勢（inbreeding depression）や交配劣勢（outbreeding depression）を指しており、うつ病の動物モデルに関する研究ではない。対象はダマガゼルという野生動物の保全遺伝学に関する研究である。"
+    ],
+    "durationMs": 5620,
+    "usage": {
+      "prompt": 621,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 769
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-672",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "強制泳ぐテスト（forced swim test）を用いてうつ関連行動（behavioral despair）を評価しており、in vivo動物モデル（Gαqノックアウトマウス）を対象としたうつ研究であるため"
+    ],
+    "durationMs": 5737,
+    "usage": {
+      "prompt": 840,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 997
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-673",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、血液凝固因子XIIIおよび免疫応答に関する動物実験である。うつ病のキーワードは含まれておらず、対象疾患が一致しない。"
+    ],
+    "durationMs": 3261,
+    "usage": {
+      "prompt": 746,
+      "completion": 81,
+      "reasoning": 0,
+      "total": 827
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-674",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が犬を用いた心臓機能に関する研究であり、うつ病（depression）の研究ではない。文中の'depression'は房室結節の抑制（心臓の機能低下）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5105,
+    "usage": {
+      "prompt": 612,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 756
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-675",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "Flinders Sensitive Line（FSL）ラットを用いたうつ病の動物モデルに関するin vivo研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 6610,
+    "usage": {
+      "prompt": 974,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 1165
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-676",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなくin vitroであるため",
+      "うつ病の動物モデルに関する記述がないため"
+    ],
+    "durationMs": 3784,
+    "usage": {
+      "prompt": 403,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 496
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-677",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした精神科臨床における薬物治療に関する記述であり、in vivo動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 4434,
+    "usage": {
+      "prompt": 800,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 912
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-678",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、視床下部損傷や過食による熱産生の制御に関する研究である"
+    ],
+    "durationMs": 4094,
+    "usage": {
+      "prompt": 649,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 761
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-679",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が抑うつではなく、血清抗体価の低下（depressed antibody titers）を指しており、呼吸抑制や心機能低下と同様に医学的機能低下の文脈で使われている",
+      "うつ病の動物モデルに関する研究ではなく、マラリア感染による免疫抑制を調べた動物実験"
+    ],
+    "durationMs": 5726,
+    "usage": {
+      "prompt": 807,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 973
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-680",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、アセチルコリン放出メカニズムに関する神経生理学的研究である"
+    ],
+    "durationMs": 2670,
+    "usage": {
+      "prompt": 843,
+      "completion": 61,
+      "reasoning": 0,
+      "total": 904
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-681",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、概日リズムの分子機構に関する基礎研究である。うつ病への言及はリチウム治療の文脈でのみあり、動物モデルでのうつ病評価や誘発は行われていない。"
+    ],
+    "durationMs": 5527,
+    "usage": {
+      "prompt": 783,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 941
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-682",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（in vivo動物モデル）であり、うつ様行動（immobility timeなど）を評価しているため、うつ病の動物モデル研究に該当する"
+    ],
+    "durationMs": 6737,
+    "usage": {
+      "prompt": 687,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 884
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-683",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5044,
+    "usage": {
+      "prompt": 569,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 714
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-684",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4406,
+    "usage": {
+      "prompt": 755,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 870
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-685",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない。羊における妊娠への黄体ホルモンの影響を調べた研究であり、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 4620,
+    "usage": {
+      "prompt": 412,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 540
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-686",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は臨床症状としての抑うつではなく、一般的な「元気消失」や「活動低下」を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4395,
+    "usage": {
+      "prompt": 753,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 863
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-687",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルが学会の全体プログラムを示しており、個別の動物実験研究を特定できない",
+      "抄録が存在せず、うつ病のin vivoモデルに関する情報を確認できない"
+    ],
+    "durationMs": 5465,
+    "usage": {
+      "prompt": 418,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 483
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-688",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い",
+      "タイトルから抗不整脈作用に関する研究と推測され、うつ病とは無関係"
+    ],
+    "durationMs": 3079,
+    "usage": {
+      "prompt": 408,
+      "completion": 78,
+      "reasoning": 0,
+      "total": 486
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-689",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトの糖尿病関連認知症（diabetic cognopathy）であり、うつ病のin vivo動物モデルに関する研究ではない。うつ病（depression）も呼吸・循環器系の抑制を指すものではなく、精神疾患としてのうつ病を対象としていない。"
+    ],
+    "durationMs": 5724,
+    "usage": {
+      "prompt": 716,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 878
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-690",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（ラット）を用いた研究であり、肥満誘発性無快楽を評価している。ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない。"
+    ],
+    "durationMs": 5231,
+    "usage": {
+      "prompt": 687,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 820
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-691",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "非ヒト霊長類（in vivo動物モデル）を用いたうつ病関連の研究であり、人間の研究ではない"
+    ],
+    "durationMs": 7366,
+    "usage": {
+      "prompt": 853,
+      "completion": 217,
+      "reasoning": 0,
+      "total": 1070
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-692",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様行動のin vivo研究であり、対象が動物モデルであることが明確"
+    ],
+    "durationMs": 5725,
+    "usage": {
+      "prompt": 808,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 971
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-693",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関するin vivo研究であり、うつ病（depressive-like behavior）を明確に扱っている"
+    ],
+    "durationMs": 6152,
+    "usage": {
+      "prompt": 677,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 835
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-694",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではない可能性が高い",
+      "タイトルに「depression」の用語が含まれておらず、ベンゾジアゼピン投与に関する研究と推測される"
+    ],
+    "durationMs": 3828,
+    "usage": {
+      "prompt": 409,
+      "completion": 68,
+      "reasoning": 0,
+      "total": 477
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-695",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はうつ病ではなく、自発的走行の減少（活動低下）を指しており、呼吸抑制や心機能抑制と同様に非精神医学的な用法である"
+    ],
+    "durationMs": 6708,
+    "usage": {
+      "prompt": 940,
+      "completion": 188,
+      "reasoning": 0,
+      "total": 1128
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-696",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が人間（無伴侶難民未成年者）であり、動物モデルではないため"
+    ],
+    "durationMs": 5875,
+    "usage": {
+      "prompt": 694,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 856
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-697",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、CD4+細胞の減少（細胞数の低下）を指している",
+      "対象がチンパンジーでありヒト研究ではないが、うつ病モデルではない",
+      "呼吸抑制や心機能抑制ではないが、依然として精神疾患モデルではないため除外"
+    ],
+    "durationMs": 6880,
+    "usage": {
+      "prompt": 799,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 949
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-698",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルからうつ病のin vivo動物モデルに関する研究であることを示す情報が全くない",
+      "むしろPityrosporum ovale（真菌）に対する新薬に関する研究と推測され、対象がうつ病ではない"
+    ],
+    "durationMs": 5185,
+    "usage": {
+      "prompt": 412,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 552
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-699",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2532,
+    "usage": {
+      "prompt": 399,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 450
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-700",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（CUMSモデル）に関するin vivo研究であり、ヒト研究ではない"
+    ],
+    "durationMs": 28455,
+    "usage": {
+      "prompt": 698,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 807
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-701",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究であり、強制水泳試験と糖水嗜好試験などのうつ様行動評価が含まれている"
+    ],
+    "durationMs": 4452,
+    "usage": {
+      "prompt": 1103,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 1221
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-702",
+    "label_included": 0,
+    "include_probability": 0.3,
+    "reasons": [
+      "抄録中に「depression」が登場するが、これは長期抑圧（long term depression, LTD）という神経生理学的現象を指しており、うつ病（depression）モデルではない。動物実験に関する記述が明確にない。"
+    ],
+    "durationMs": 4871,
+    "usage": {
+      "prompt": 695,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 830
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-703",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルではなく、カエルの下垂体メラノトロフ細胞を用いた内分泌機能の研究である",
+      "「depression」という語が出現しない、または出現しても呼吸抑制などを意味する可能性があるが、本抄録では「depression」は電流の抑制を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 7806,
+    "usage": {
+      "prompt": 917,
+      "completion": 219,
+      "reasoning": 0,
+      "total": 1136
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-704",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病を指しておらず、人口規模の減少（population size depression）を意味している",
+      "動物モデルを用いたうつ病研究ではなく、寄生虫とアリー効果による絶滅ダイナミクスに関する理論的生態学の研究"
+    ],
+    "durationMs": 5943,
+    "usage": {
+      "prompt": 589,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 730
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-705",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト症例報告であり、動物モデルではない",
+      "「depression」は呼吸抑制（respiratory depression）を指しており、うつ病ではない"
+    ],
+    "durationMs": 5627,
+    "usage": {
+      "prompt": 601,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 752
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-706",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "強制泳泳テスト（FST）というin vivoうつ病モデルを用いて抗うつ様効果を評価している"
+    ],
+    "durationMs": 4261,
+    "usage": {
+      "prompt": 607,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 715
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-707",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたアルツハイマー病の臨床研究であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 8793,
+    "usage": {
+      "prompt": 1002,
+      "completion": 206,
+      "reasoning": 0,
+      "total": 1208
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-708",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデル（強制水泳試験）に関する動物実験であり、人間の研究ではない"
+    ],
+    "durationMs": 5656,
+    "usage": {
+      "prompt": 559,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 708
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-709",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットおよびマウスを用いたうつ病モデルの動物実験であり、精神的うつ病を評価している"
+    ],
+    "durationMs": 7316,
+    "usage": {
+      "prompt": 693,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 846
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-710",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がムール貝のタンパク質に関する研究であり、うつ病のin vivo動物モデルを対象としていない。また、「depression」という語は足部の解剖学的くぼみを指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 5258,
+    "usage": {
+      "prompt": 611,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 747
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-711",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が猫の視覚皮質の神経活動に関する研究であり、うつ病のin vivoモデルではない",
+      "抄録およびタイトルに「depression（うつ病）」の記載がなく、呼吸抑制や心機能抑制などの「depression」も含まれていない"
+    ],
+    "durationMs": 3808,
+    "usage": {
+      "prompt": 605,
+      "completion": 94,
+      "reasoning": 0,
+      "total": 699
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-712",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく皮質拡延性抑制（cortical spreading depression）を指しており、これは神経生理学的現象であり、うつ病モデルではない"
+    ],
+    "durationMs": 4628,
+    "usage": {
+      "prompt": 470,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 585
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-713",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「animal models」と明記されており、うつ病のin vivo動物モデルに関する研究である可能性が高い"
+    ],
+    "durationMs": 3756,
+    "usage": {
+      "prompt": 405,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 496
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-714",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoのうつ病モデル（マウス）を用いた研究であり、うつ病治療薬の効果を評価している"
+    ],
+    "durationMs": 6715,
+    "usage": {
+      "prompt": 752,
+      "completion": 190,
+      "reasoning": 0,
+      "total": 942
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-715",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や酵素活性の低下など、うつ病とは無関係な文脈で使用されている",
+      "うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4389,
+    "usage": {
+      "prompt": 881,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 1004
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-716",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病のin vivoモデルに関する動物研究であり、うつ病の神経生物学的メカニズムおよび抗うつ作用を評価している"
+    ],
+    "durationMs": 6982,
+    "usage": {
+      "prompt": 872,
+      "completion": 201,
+      "reasoning": 0,
+      "total": 1073
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-717",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 4970,
+    "usage": {
+      "prompt": 746,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 858
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-718",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoうつ病モデルの動物研究ではなく、グリア細胞株を用いたin vitro実験であるため"
+    ],
+    "durationMs": 3980,
+    "usage": {
+      "prompt": 706,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 808
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-719",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「Phase II depression trial」とあり、ヒトを対象とした臨床試験であることが明確であるため、動物研究ではない"
+    ],
+    "durationMs": 4463,
+    "usage": {
+      "prompt": 401,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 503
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-720",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（ventilatory depression）を指しており、うつ病モデルではないため"
+    ],
+    "durationMs": 3813,
+    "usage": {
+      "prompt": 678,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 773
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-721",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3432,
+    "usage": {
+      "prompt": 671,
+      "completion": 85,
+      "reasoning": 0,
+      "total": 756
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-722",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（in vivo動物モデル）であり、うつ病の行動モデル（強制水泳試験）を用いているため"
+    ],
+    "durationMs": 4560,
+    "usage": {
+      "prompt": 701,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 820
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-723",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は気分障害としてのうつ病ではなく、痛みによって抑圧された行動（pain-depressed behavior）を指しており、呼吸抑制や循環抑制と同様に除外対象の「depression」である"
+    ],
+    "durationMs": 7640,
+    "usage": {
+      "prompt": 840,
+      "completion": 223,
+      "reasoning": 0,
+      "total": 1063
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-724",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、血管弛緩に関する研究である"
+    ],
+    "durationMs": 6996,
+    "usage": {
+      "prompt": 831,
+      "completion": 198,
+      "reasoning": 0,
+      "total": 1029
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-725",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルに関する記述が明確に含まれており、in vivo動物研究の対象であると判断されるため"
+    ],
+    "durationMs": 4625,
+    "usage": {
+      "prompt": 679,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 794
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-726",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト以外の動物（犬）であるが、研究テーマがうつ病モデルではなく、麻酔下におけるナルキソノンの心血管作用に焦点を当てており、うつ病（depression）は呼吸抑制を指している。"
+    ],
+    "durationMs": 4784,
+    "usage": {
+      "prompt": 634,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 766
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-727",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "抄録に「depression」の動物モデルに関する記述があり、in vivo動物研究を対象としていると明記されているため"
+    ],
+    "durationMs": 4276,
+    "usage": {
+      "prompt": 477,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 584
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-728",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がイヌの心筋であり、うつ病のin vivoモデルではない。また、「depression」は呼吸抑制を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 4653,
+    "usage": {
+      "prompt": 934,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 1051
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-729",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト症例報告であり、うつ病の動物モデルに関する研究ではない",
+      "「depression」が呼吸抑制などを指す文脈ではなく、そもそもうつ病自体が対象とされていない"
+    ],
+    "durationMs": 4453,
+    "usage": {
+      "prompt": 554,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 675
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-730",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4060,
+    "usage": {
+      "prompt": 683,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 795
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-731",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラットの横隔膜神経-横隔膜標本であり、うつ病のin vivoモデルではない",
+      "実験がin vitroで実施されており、in vivoモデルの要件を満たさない",
+      "うつ病（depression）に関する研究ではなく、筋収縮とカルシウム流入の研究である"
+    ],
+    "durationMs": 7992,
+    "usage": {
+      "prompt": 534,
+      "completion": 236,
+      "reasoning": 0,
+      "total": 770
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-732",
+    "label_included": 0,
+    "include_probability": 0.9,
+    "reasons": [
+      "タイトルに「in animals」と明記されており、うつ病の動物モデル研究の可能性が高いが、抄録がなく詳細が不明なため、感度を優先して含める"
+    ],
+    "durationMs": 4484,
+    "usage": {
+      "prompt": 401,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 511
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-733",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病を指しておらず、心臓の抑制（陰性変時効果）に関する研究である"
+    ],
+    "durationMs": 5378,
+    "usage": {
+      "prompt": 791,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 944
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-734",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4364,
+    "usage": {
+      "prompt": 678,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 786
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-735",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が肝臓グリコーゲン分解の抑制（glycogenolysis depressing actions）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4456,
+    "usage": {
+      "prompt": 625,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 744
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-736",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、急性固定ストレス下での性腺刺激ホルモン分泌の抑制を調べた研究である。「depression」の語も使用されていない。"
+    ],
+    "durationMs": 2862,
+    "usage": {
+      "prompt": 770,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 835
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-737",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」の記載がなく、脂肪肝のラットモデルに関する研究であるため、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 2913,
+    "usage": {
+      "prompt": 411,
+      "completion": 66,
+      "reasoning": 0,
+      "total": 477
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-738",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であるという根拠がない",
+      "「reserpine」はうつ病モデルに使われることもあるが、本タイトルは心臓の血流供給に焦点を当てており、うつ病との関連が不明確",
+      "抄録が存在せず、うつ病（精神疾患）の文脈であるか判断できないが、タイトルから推測される内容は心血管系に特化しており、除外基準に該当する可能性が高い"
+    ],
+    "durationMs": 6862,
+    "usage": {
+      "prompt": 399,
+      "completion": 195,
+      "reasoning": 0,
+      "total": 594
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-739",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が脂質再エステル化酵素の抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4155,
+    "usage": {
+      "prompt": 405,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 507
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-740",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、食欲抑制に関する研究である"
+    ],
+    "durationMs": 2206,
+    "usage": {
+      "prompt": 796,
+      "completion": 44,
+      "reasoning": 0,
+      "total": 840
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-741",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、生理機能の低下（例：子宮重量や血流の「depressed」）を指しており、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 7395,
+    "usage": {
+      "prompt": 797,
+      "completion": 221,
+      "reasoning": 0,
+      "total": 1018
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-742",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2514,
+    "usage": {
+      "prompt": 413,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 464
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-743",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではないと判断される",
+      "タイトルに「depression」や「うつ病」に関連する用語が含まれていない"
+    ],
+    "durationMs": 2509,
+    "usage": {
+      "prompt": 411,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 470
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-744",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）に関する言及がなく、研究対象が動物モデルであるか不明であり、代謝や脂質分解に関する研究と推測されるため"
+    ],
+    "durationMs": 3018,
+    "usage": {
+      "prompt": 420,
+      "completion": 73,
+      "reasoning": 0,
+      "total": 493
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-745",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はシナプス伝達の抑制（long-term depressionなど）を指しており、うつ病モデルではない",
+      "動物実験かどうか明記されていないが、うつ病のin vivoモデルに関する記述が全くない"
+    ],
+    "durationMs": 5437,
+    "usage": {
+      "prompt": 583,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 727
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-746",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2385,
+    "usage": {
+      "prompt": 416,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 469
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-747",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」または「depression」の記載がなく、結核および甲状腺に関する研究であることが示唆されているため、うつ病のin vivoモデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 3098,
+    "usage": {
+      "prompt": 404,
+      "completion": 69,
+      "reasoning": 0,
+      "total": 473
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-748",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、糖尿病ラットにおけるリノール酸の代謝に関する研究である"
+    ],
+    "durationMs": 4106,
+    "usage": {
+      "prompt": 406,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 513
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-749",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "抄録に「depression」を含む精神疾患の行動モデルを用いたin vivo動物実験に関する記述があり、うつ病の動物モデル研究であると判断できる"
+    ],
+    "durationMs": 5072,
+    "usage": {
+      "prompt": 685,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-750",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的抑制（反復性抑制の減弱）を指しており、うつ病（depression as a mood disorder）の動物モデルではない"
+    ],
+    "durationMs": 5898,
+    "usage": {
+      "prompt": 671,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 842
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-751",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルを対象とした研究ではなく、モルヒネによる運動活性化および感受性形成の研究である。うつ病に関する記述が全くない。"
+    ],
+    "durationMs": 3333,
+    "usage": {
+      "prompt": 564,
+      "completion": 70,
+      "reasoning": 0,
+      "total": 634
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-752",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、脳内の「spreading depression（拡がり性抑制）」を指しており、うつ病モデルではない",
+      "対象がカエルの網膜であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 6579,
+    "usage": {
+      "prompt": 643,
+      "completion": 189,
+      "reasoning": 0,
+      "total": 832
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-753",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の明示的な記載がなく、動物実験かどうか判断できないため"
+    ],
+    "durationMs": 2653,
+    "usage": {
+      "prompt": 431,
+      "completion": 58,
+      "reasoning": 0,
+      "total": 489
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-754",
+    "label_included": 1,
+    "include_probability": 0.9,
+    "reasons": [
+      "「Depressive behavioral effects」とあるが、文脈から行動性の抑うつ様症状を指しており、呼吸抑制や心機能抑制ではない可能性が高い。in vivo動物実験と推定され、うつ病モデルに関連する可能性があるため、感度を優先して含める。"
+    ],
+    "durationMs": 5027,
+    "usage": {
+      "prompt": 506,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 642
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-755",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅覚球摘出ラットを用いたうつ病のin vivoモデルに関する動物研究であり、対象とするうつ病は精神疾患としてのうつ病である"
+    ],
+    "durationMs": 6167,
+    "usage": {
+      "prompt": 716,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-756",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する用語が含まれておらず、肝細胞を用いたコレステロール代謝研究であるため、うつ病のin vivo動物モデルの研究ではないと判断される"
+    ],
+    "durationMs": 3191,
+    "usage": {
+      "prompt": 404,
+      "completion": 80,
+      "reasoning": 0,
+      "total": 484
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-757",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病モデルの動物実験であり、呼吸・心臓などの「depression」とは無関係である"
+    ],
+    "durationMs": 6153,
+    "usage": {
+      "prompt": 727,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 905
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-758",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、不全前脳虚血モデルを用いた脳保護効果の検討である"
+    ],
+    "durationMs": 5632,
+    "usage": {
+      "prompt": 844,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 997
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-759",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が水牛（buffaloes）であり、うつ病の動物モデルに関する研究ではない。",
+      "「depression」という言葉は心臓や呼吸の抑制（cardiopulmonary depression）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5417,
+    "usage": {
+      "prompt": 1139,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 1283
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-760",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラットの腫瘍細胞および線維芽細胞であり、うつ病のin vivoモデルに関する研究ではない",
+      "抄録中に「depression（うつ病）」という用語が一切含まれておらず、呼吸性うつや心機能低下などの他の意味での「depression」も言及されていない"
+    ],
+    "durationMs": 4070,
+    "usage": {
+      "prompt": 684,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 791
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-761",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoマウスモデルを用いたうつ病関連行動の研究であり、対象が動物実験である"
+    ],
+    "durationMs": 5300,
+    "usage": {
+      "prompt": 825,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 974
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-762",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や循環抑制などの生理的抑制を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 4331,
+    "usage": {
+      "prompt": 840,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 955
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-763",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、ラットの孤立肛尾筋における神経伝達の薬理学的影響を調べたもの"
+    ],
+    "durationMs": 7001,
+    "usage": {
+      "prompt": 879,
+      "completion": 203,
+      "reasoning": 0,
+      "total": 1082
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-764",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4299,
+    "usage": {
+      "prompt": 810,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 915
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-765",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などではなく、うつ病を指しているか明確でないが、抄録中の「depression of ADP:O」はミトコンドリア機能の抑制（機能低下）を意味しており、うつ病モデルではないと判断できる。また、研究対象は高血圧ラットであり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 6499,
+    "usage": {
+      "prompt": 725,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 895
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-766",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経科学における長期抑圧（long-term depression, LTD）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5480,
+    "usage": {
+      "prompt": 953,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 1110
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-767",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がシナプスの短期抑圧（short-term synaptic depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3934,
+    "usage": {
+      "prompt": 619,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 726
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-768",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "抄録が存在せず、研究内容の判断ができないが、タイトルから血小板凝集に関する研究と推測され、うつ病とは無関係"
+    ],
+    "durationMs": 5299,
+    "usage": {
+      "prompt": 404,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 551
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-769",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト以外の動物（マーモセットザル）を対象とした研究だが、うつ病モデルではなく、睡眠中の感覚応答に関する研究である。うつ病（depression）は本研究では取り扱われておらず、また「depression」の語も呼吸抑制などの文脈でも使われていない。"
+    ],
+    "durationMs": 7488,
+    "usage": {
+      "prompt": 642,
+      "completion": 224,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-770",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「long-term depression (LTD)」は神経科学におけるシナプス可塑性の用語であり、うつ病（depression）の動物モデルを指していない",
+      "うつ病のin vivoモデルに関する記述が一切含まれていない"
+    ],
+    "durationMs": 4657,
+    "usage": {
+      "prompt": 680,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 810
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-771",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4265,
+    "usage": {
+      "prompt": 831,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 930
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-772",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が代謝の低下（depressed metabolism）を指しており、うつ病モデルの動物実験ではない",
+      "呼吸器や心臓の機能低下ではなくとも、精神疾患としてのうつ病に関する研究ではない"
+    ],
+    "durationMs": 6563,
+    "usage": {
+      "prompt": 839,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 1005
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-773",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸・心臓・元素レベルの低下を指しており、うつ病モデルではない",
+      "うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5010,
+    "usage": {
+      "prompt": 793,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 927
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-774",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や神経生理学的抑制（グルタミン酸誘発発火の抑制）を指しており、うつ病モデルではないため",
+      "動物実験ではあるが、うつ病のin vivoモデルを対象としていない"
+    ],
+    "durationMs": 5696,
+    "usage": {
+      "prompt": 643,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 791
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-775",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "授乳中のげっ歯類を用いたうつ病のin vivoモデルに関する動物実験であり、対象とするうつ病は精神疾患としてのうつ病である"
+    ],
+    "durationMs": 6924,
+    "usage": {
+      "prompt": 593,
+      "completion": 199,
+      "reasoning": 0,
+      "total": 792
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-776",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「CNS depression」とあるが、これは中枢神経抑制を指しており、うつ病（depression）の動物モデルではない。うつ病関連の評価やモデルが記載されていない。"
+    ],
+    "durationMs": 5004,
+    "usage": {
+      "prompt": 689,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 807
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-777",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、未熟雌ラットにおける排卵に関する研究である"
+    ],
+    "durationMs": 4519,
+    "usage": {
+      "prompt": 417,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 528
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-778",
+    "label_included": 0,
+    "include_probability": 0.3,
+    "reasons": [
+      "うつ病の動物モデルを直接評価した研究ではなく、ストレス後の睡眠リバウンドにおける脳内活性の変化を調べたものであり、「うつ病」は病態的結果の可能性として言及されているにとどまる。"
+    ],
+    "durationMs": 5488,
+    "usage": {
+      "prompt": 831,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 974
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-779",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」が神経生理学的現象（ホモシナプティック抑制）を指しており、うつ病（depression as a mood disorder）の動物モデルではないと判断される"
+    ],
+    "durationMs": 4765,
+    "usage": {
+      "prompt": 424,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-780",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病関連のin vivo研究であり、ヒト研究や呼吸・循環抑制などの非精神疾患のうつではない"
+    ],
+    "durationMs": 8576,
+    "usage": {
+      "prompt": 726,
+      "completion": 260,
+      "reasoning": 0,
+      "total": 986
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-781",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（うつ病患者およびクッシング症候群患者）であり、動物研究ではない"
+    ],
+    "durationMs": 5187,
+    "usage": {
+      "prompt": 631,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 767
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-782",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が牛（家畜）であり、うつ病のin vivo動物モデルに関する研究ではない。「depression」という語は細胞増殖の抑制（熱ストレスによる）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 7024,
+    "usage": {
+      "prompt": 733,
+      "completion": 200,
+      "reasoning": 0,
+      "total": 933
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-783",
+    "label_included": 0,
+    "include_probability": 0.95,
+    "reasons": [
+      "躁うつ病（双極性障害）の動物モデルに関する研究であり、うつ病のin vivoモデルとして関連する可能性があるため"
+    ],
+    "durationMs": 4547,
+    "usage": {
+      "prompt": 903,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 1026
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-784",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "研究対象がカエル（Rana temporaria）の脈絡叢におけるグリコーゲン貯蔵であり、うつ病とは無関係"
+    ],
+    "durationMs": 4956,
+    "usage": {
+      "prompt": 414,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 551
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-785",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病関連の動物実験であり、in vivoモデルに該当する。呼吸性または心臓性の「depression」ではない。"
+    ],
+    "durationMs": 5711,
+    "usage": {
+      "prompt": 805,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 961
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-786",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経活動の抑制（raphe unit activityの減少）を指しており、うつ病モデルではない。対象は猫だが、うつ病のin vivoモデルとしての記述はなく、行動も幻覚性行動（limb flick, abortive groom）でありうつ病関連行動ではない。"
+    ],
+    "durationMs": 5641,
+    "usage": {
+      "prompt": 610,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 753
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-787",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてではなく、シナプス機能の文脈における「synaptic depression（シナプス抑制）」として使用されており、うつ病の動物モデルを対象とした研究ではない"
+    ],
+    "durationMs": 4851,
+    "usage": {
+      "prompt": 788,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 918
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-788",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が長期増強（LTP）の抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5095,
+    "usage": {
+      "prompt": 597,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 733
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-789",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病のin vivo動物モデル研究であり、ヒト研究や呼吸・心臓の抑制とは無関係である"
+    ],
+    "durationMs": 6129,
+    "usage": {
+      "prompt": 831,
+      "completion": 173,
+      "reasoning": 0,
+      "total": 1004
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-790",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、動物実験であるため"
+    ],
+    "durationMs": 6050,
+    "usage": {
+      "prompt": 959,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 1107
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-791",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や自律神経抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3831,
+    "usage": {
+      "prompt": 1027,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 1129
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-792",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が神経症状（抑うつ状態）ではなく、一般的な臨床症状（無気力・沈鬱）として使用されており、うつ病モデルの動物実験ではない。研究対象は腫瘍（奇形腫）に関する症例報告であり、うつ病のin vivoモデルを扱っていない。"
+    ],
+    "durationMs": 5681,
+    "usage": {
+      "prompt": 623,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 787
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-793",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病モデルの動物実験であり、うつ病（anhedonia）を評価している"
+    ],
+    "durationMs": 5981,
+    "usage": {
+      "prompt": 745,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 913
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-794",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "研究対象がカエル（Rana hexadactyla）であり、うつ病ではなく生殖機能に焦点を当てている"
+    ],
+    "durationMs": 4878,
+    "usage": {
+      "prompt": 420,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 553
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-795",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性があるが、本研究では「bombesin depressed body weight」とあるように、体重減少を意味しており、うつ病モデルではない。また、研究はラットを用いているが、うつ病のin vivoモデルとしての記載はなく、副腎皮質へのbombesinの影響を調べたものである。"
+    ],
+    "durationMs": 6136,
+    "usage": {
+      "prompt": 616,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 777
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-796",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 2521,
+    "usage": {
+      "prompt": 412,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 469
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-797",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉がうつ病ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4751,
+    "usage": {
+      "prompt": 854,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 972
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-798",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、ストレス誘発性鎮痛に焦点を当てた動物実験であり、うつ病の評価やモデル化が行われていない"
+    ],
+    "durationMs": 7950,
+    "usage": {
+      "prompt": 568,
+      "completion": 225,
+      "reasoning": 0,
+      "total": 793
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-799",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトまたは動物を対象としたうつ病のin vivoモデルに関する研究ではなく、in vitro細胞実験（HT-22マウス海馬細胞、N2aマウス神経芽腫細胞、HEK293ヒト腎細胞）のみを対象としている",
+      "「うつ病」は臨床的うつ病（ヒト）に関連して言及されており、動物モデルでのうつ病評価ではない"
+    ],
+    "durationMs": 10087,
+    "usage": {
+      "prompt": 810,
+      "completion": 295,
+      "reasoning": 0,
+      "total": 1105
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-800",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」や「うつ病」に関連する用語が含まれておらず、呼吸抑制や心機能抑制などの「depression」の誤解も該当しない。対象がヒスタミン遊離作用とヒト血清アルブミンであり、in vivo うつ病モデルの動物研究ではない。"
+    ],
+    "durationMs": 5653,
+    "usage": {
+      "prompt": 412,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 574
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-801",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく「inbreeding depression（近交劣勢）」を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 6040,
+    "usage": {
+      "prompt": 644,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 800
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-802",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（ラット）を用いた研究であり、強制水泳試験（FST）で抑うつ様行動を評価しているため"
+    ],
+    "durationMs": 6055,
+    "usage": {
+      "prompt": 758,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 934
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-803",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指す文脈ではなく、本研究では「growth depression（成長抑制）」という用語が使われており、うつ病（depression）の動物モデルに関する研究ではない。対象はFusarium菌の培養と栄養評価であり、うつ病の研究ではない。"
+    ],
+    "durationMs": 5447,
+    "usage": {
+      "prompt": 691,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 846
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-804",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「cardiac depression（心臓抑制）」を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4065,
+    "usage": {
+      "prompt": 784,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-805",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病研究であり、動物モデルを使用していないため除外"
+    ],
+    "durationMs": 4182,
+    "usage": {
+      "prompt": 648,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 762
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-806",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルに関する研究ではなく、マクロファージの炎症反応とプロテアソーム活性に焦点を当てた動物実験である。「うつ病（depression）」という用語は一切使用されておらず、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 3999,
+    "usage": {
+      "prompt": 670,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 773
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-807",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ウイルス抗原誘導の細胞実験である"
+    ],
+    "durationMs": 2295,
+    "usage": {
+      "prompt": 575,
+      "completion": 50,
+      "reasoning": 0,
+      "total": 625
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-808",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病モデルに関する動物研究かどうか判断できない",
+      "がん治療（antineoplastic effect）に関する研究の可能性が高く、うつ病とは無関係と推測される"
+    ],
+    "durationMs": 3159,
+    "usage": {
+      "prompt": 409,
+      "completion": 76,
+      "reasoning": 0,
+      "total": 485
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-809",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない。排卵率および血清LH濃度に焦点を当てており、うつ病とは無関係である。"
+    ],
+    "durationMs": 4541,
+    "usage": {
+      "prompt": 411,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 530
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-810",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした臨床試験であり、動物モデルではないため"
+    ],
+    "durationMs": 4235,
+    "usage": {
+      "prompt": 1157,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 1254
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-811",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気温ストレスによる生産性の低下（performance depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4255,
+    "usage": {
+      "prompt": 805,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 912
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-812",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 2666,
+    "usage": {
+      "prompt": 404,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 461
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-813",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が抑うつではなく脊髄反射の抑制（生理学的抑制）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5408,
+    "usage": {
+      "prompt": 642,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 794
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-814",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、マウス胚発生のin vitro研究である"
+    ],
+    "durationMs": 4308,
+    "usage": {
+      "prompt": 411,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 517
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-815",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「Sertraline hydrochloride」とあるが、動物実験か人間研究か、あるいはうつ病モデルに関するものか不明である。抄録がなく、判断に必要な情報が不足している。"
+    ],
+    "durationMs": 4394,
+    "usage": {
+      "prompt": 395,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 512
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-816",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルではなく、三叉神経由来の興奮性シナプス伝達に関する神経生理学的研究である。"
+    ],
+    "durationMs": 7516,
+    "usage": {
+      "prompt": 635,
+      "completion": 223,
+      "reasoning": 0,
+      "total": 858
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-817",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が情動行動に関連する脳機能の抑制を指しており、うつ病モデルではない",
+      "呼吸抑制や循環抑制など生理学的抑制作用を調べた動物実験であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6370,
+    "usage": {
+      "prompt": 619,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 801
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-818",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が神経伝達物質の合成や放出の抑制を指しており、うつ病モデルではない",
+      "うつ病（depression）のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4946,
+    "usage": {
+      "prompt": 512,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 640
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-819",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "アルツハイマー病のトランスジェニックマウスを用いたうつ行動の研究であり、in vivo動物モデルを使用しているため"
+    ],
+    "durationMs": 7731,
+    "usage": {
+      "prompt": 739,
+      "completion": 226,
+      "reasoning": 0,
+      "total": 965
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-820",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「long-term depression (LTD)」として神経科学的現象を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5920,
+    "usage": {
+      "prompt": 636,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 784
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-821",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「心筋抑制（myocardial depression）」を指しており、うつ病（depression）の動物モデルではない",
+      "対象は心筋細胞（cardiac myocytes）であり、うつ病の神経行動学的モデルではない"
+    ],
+    "durationMs": 5481,
+    "usage": {
+      "prompt": 803,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 960
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-822",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2872,
+    "usage": {
+      "prompt": 398,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 453
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-823",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や循環器などの生理機能の抑制を指しており、うつ病モデルではないと判断される",
+      "対象がモルモットであるが、うつ病のin vivoモデルではなく、血液凝固関連の研究と推測される"
+    ],
+    "durationMs": 4765,
+    "usage": {
+      "prompt": 409,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 542
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-824",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫応答の抑制を指しており、うつ病（depression）の動物モデルではない",
+      "対象はヒトではないが、うつ病の研究ではないため除外対象"
+    ],
+    "durationMs": 4601,
+    "usage": {
+      "prompt": 644,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 767
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-825",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 2340,
+    "usage": {
+      "prompt": 419,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 472
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-826",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が不安障害の動物モデルであり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 7025,
+    "usage": {
+      "prompt": 658,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-827",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は細胞媒介性免疫の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3845,
+    "usage": {
+      "prompt": 665,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 760
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-828",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が「inbreeding depression（近親交配による劣勢）」を指しており、うつ病（depression）の動物モデルに関する研究ではない",
+      "抄録全体を通じてうつ病やその動物モデルに関する記述が一切ない"
+    ],
+    "durationMs": 5163,
+    "usage": {
+      "prompt": 777,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 913
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-829",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「Animal model of depression」と明記されており、抄録からラットを用いたうつ病モデルに関する生体内研究であることが確認できる。呼吸性うつや心機能低下など、他の意味での「depression」ではない。"
+    ],
+    "durationMs": 4671,
+    "usage": {
+      "prompt": 683,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 807
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-830",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指しており、うつ病モデルではない",
+      "がん予防に関する動物実験であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4455,
+    "usage": {
+      "prompt": 642,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 762
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-831",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした遺伝関連研究であり、動物モデルを使用していない"
+    ],
+    "durationMs": 4744,
+    "usage": {
+      "prompt": 801,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 910
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-832",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから動物実験（in vivo）ではなくin vitro研究であることが明確であり、うつ病モデルではない"
+    ],
+    "durationMs": 3573,
+    "usage": {
+      "prompt": 409,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 500
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-833",
+    "label_included": 1,
+    "include_probability": 0.7,
+    "reasons": [
+      "タイトルに「行動学的および薬理学的研究」とあり、動物モデルでの研究の可能性があるが、対象が動物か人間か明記されていないため不確実"
+    ],
+    "durationMs": 5263,
+    "usage": {
+      "prompt": 435,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 584
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-834",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経科学における長期抑圧（long-term depression, LTD）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5333,
+    "usage": {
+      "prompt": 701,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 851
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-835",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4090,
+    "usage": {
+      "prompt": 771,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-836",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、カルシウム吸収と副甲状腺ホルモンに関する動物実験である"
+    ],
+    "durationMs": 2611,
+    "usage": {
+      "prompt": 750,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 809
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-837",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が呼吸抑制や心機能抑制などを指す文脈ではなく、細胞増殖の抑制を意味しているが、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4908,
+    "usage": {
+      "prompt": 647,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 779
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-838",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoのラットを用いたうつ病モデルに関する動物実験である"
+    ],
+    "durationMs": 5671,
+    "usage": {
+      "prompt": 855,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 1013
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-839",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、カエルの神経筋接合部におけるランタンイオンの影響を調べた研究である"
+    ],
+    "durationMs": 4325,
+    "usage": {
+      "prompt": 406,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 517
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-840",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、対象とするin vivo研究に該当する"
+    ],
+    "durationMs": 6034,
+    "usage": {
+      "prompt": 618,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 790
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-841",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病治療のパイロットオープンラベル研究であり、動物モデルを使用していない"
+    ],
+    "durationMs": 5844,
+    "usage": {
+      "prompt": 711,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 869
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-842",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデル研究であり、強制水泳試験を実施している。動物研究であり、呼吸抑制などの他の「depression」とは無関係。"
+    ],
+    "durationMs": 8157,
+    "usage": {
+      "prompt": 930,
+      "completion": 240,
+      "reasoning": 0,
+      "total": 1170
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-843",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が成長抑制（growth depression）を指しており、うつ病（depression）の動物モデルではない",
+      "対象はヒナ（chicks）だが、うつ病の行動的または神経生物学的モデルに関する記述は一切含まれていない",
+      "研究目的は ochratoxin A とコクシジウム症の影響であり、うつ病とは無関係"
+    ],
+    "durationMs": 7522,
+    "usage": {
+      "prompt": 650,
+      "completion": 226,
+      "reasoning": 0,
+      "total": 876
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-844",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は細胞性免疫の抑制（depression of the response）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3714,
+    "usage": {
+      "prompt": 527,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 627
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-845",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、カエル心臓における陰性変力作用を調べた研究である。「depression」は心機能の抑制（cardiac depression）を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 4492,
+    "usage": {
+      "prompt": 582,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 702
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-846",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoのラットを用いたうつ病関連薬物の研究であり、うつ病モデル動物研究に該当する"
+    ],
+    "durationMs": 4065,
+    "usage": {
+      "prompt": 689,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 800
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-847",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（患者）であり、動物モデルではない"
+    ],
+    "durationMs": 4696,
+    "usage": {
+      "prompt": 1227,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 1356
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-848",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、腎臓の重炭酸イオン再吸収に関する生理学的研究である",
+      "「depression」が「抑制」（例: depressive effect）の意味で使われており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 5227,
+    "usage": {
+      "prompt": 696,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 838
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-849",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「psychotropic drugs（向精神薬）」が含まれるため、うつ病の動物モデル研究の可能性があるが、抄録がなく研究対象が動物か人間か、うつ病に関連するか不明であるため、感度を優先して含める可能性を考慮"
+    ],
+    "durationMs": 4999,
+    "usage": {
+      "prompt": 398,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-850",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究であり、うつ病様行動を評価している"
+    ],
+    "durationMs": 5792,
+    "usage": {
+      "prompt": 726,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 887
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-851",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病の動物モデルに関する研究であり、ヒト研究ではない。うつ病治療薬ケタミンの作用を調べており、「うつ病」は気分障害としてのうつ病を指している。"
+    ],
+    "durationMs": 7836,
+    "usage": {
+      "prompt": 1184,
+      "completion": 228,
+      "reasoning": 0,
+      "total": 1412
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-852",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、脳スライスを用いた神経生理学的実験である"
+    ],
+    "durationMs": 5003,
+    "usage": {
+      "prompt": 908,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 1031
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-853",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、末梢神経における抑制性および興奮性シナプス電位の相互作用を調べた神経生理学的研究である。「depression」は電位振幅の「抑制」を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 5424,
+    "usage": {
+      "prompt": 548,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 699
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-854",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のラットを用いたin vivo研究であり、動物モデルに関する記述がある"
+    ],
+    "durationMs": 5146,
+    "usage": {
+      "prompt": 721,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 863
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-855",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様状態のin vivoモデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の「depression」ではない"
+    ],
+    "durationMs": 5709,
+    "usage": {
+      "prompt": 864,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 1026
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-856",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「long-term depression」は神経科学における長期抑圧（LTD）を指しており、うつ病（depression）ではない",
+      "うつ病モデル動物を用いた研究ではなく、インスリン抵抗性ラットを対象とした代謝研究である",
+      "うつ病（depression）という用語が呼吸性・心臓性の抑制ではなく神経可塑性の文脈で使われているが、それでも精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 6418,
+    "usage": {
+      "prompt": 759,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 944
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-857",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "糖尿病ラットを用いたうつ病様行動に関するin vivo動物実験であり、うつ病（depression）が精神疾患として扱われている"
+    ],
+    "durationMs": 7021,
+    "usage": {
+      "prompt": 712,
+      "completion": 209,
+      "reasoning": 0,
+      "total": 921
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-858",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や神経筋接合部の抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5664,
+    "usage": {
+      "prompt": 636,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 796
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-859",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、視細胞におけるカルシウム電流の調節メカニズムに関する研究である。「depression」は本抄録で電流の抑制（depression of currents）を指しており、精神疾患としてのうつ病とは無関係である。動物実験ではあるが、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 6322,
+    "usage": {
+      "prompt": 816,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 991
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-860",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が長期抑圧（LTD）を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病のin vivoモデルに関する記述が一切ない"
+    ],
+    "durationMs": 4541,
+    "usage": {
+      "prompt": 999,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 1118
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-861",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」とあるが、動物研究かどうか不明であり、抄録が存在しないため判断できない。感作性を重視し、除外は避けるべき。"
+    ],
+    "durationMs": 3782,
+    "usage": {
+      "prompt": 394,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 498
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-862",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様状態（dysphoria-like state）のin vivo研究であり、対象とする動物モデルに該当する"
+    ],
+    "durationMs": 5784,
+    "usage": {
+      "prompt": 522,
+      "completion": 169,
+      "reasoning": 0,
+      "total": 691
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-863",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経筋接合部における薬理的抑制（抑制作用）を指しており、うつ病モデルではない",
+      "研究対象がうつ病のin vivo動物モデルではなく、神経筋機能および麻酔作用の評価である"
+    ],
+    "durationMs": 7084,
+    "usage": {
+      "prompt": 603,
+      "completion": 206,
+      "reasoning": 0,
+      "total": 809
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-864",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（tail suspension test）でのin vivo試験が実施されており、動物研究であることが明確"
+    ],
+    "durationMs": 5064,
+    "usage": {
+      "prompt": 1216,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 1360
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-865",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫応答の抑制を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3849,
+    "usage": {
+      "prompt": 651,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 755
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-866",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれていない",
+      "心筋の機械的性能および弛緩に関する研究であり、うつ病の動物モデルではない",
+      "「depression」が呼吸抑制や心機能抑制を指す可能性があるが、本研究はそれらにも該当しない"
+    ],
+    "durationMs": 5894,
+    "usage": {
+      "prompt": 423,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 586
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-867",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す情報がない"
+    ],
+    "durationMs": 2803,
+    "usage": {
+      "prompt": 408,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 463
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-868",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルおよび抄録から、マウスを用いた強制水泳試験（FST）および尾部懸垂試験（TST）といったうつ病の動物モデルを用いた研究であることが明確であり、ヒト研究や呼吸・循環器系の「depression」とは無関係である"
+    ],
+    "durationMs": 7170,
+    "usage": {
+      "prompt": 805,
+      "completion": 213,
+      "reasoning": 0,
+      "total": 1018
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-869",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、交感神経節の軸索スプラウトとノルエピネフリン取り込みに関する基礎神経科学の研究である"
+    ],
+    "durationMs": 5217,
+    "usage": {
+      "prompt": 504,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 644
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-870",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、乳腺腫瘍およびプロラクチンレベルに関する研究である"
+    ],
+    "durationMs": 4192,
+    "usage": {
+      "prompt": 415,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 531
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-871",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性予測不可能な軽度ストレス（CUMS）を用いたマウスのうつ病モデルに関するin vivo研究であり、動物実験であることが明確である。"
+    ],
+    "durationMs": 4713,
+    "usage": {
+      "prompt": 834,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 957
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-872",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓の活動電位における脱分極最大速度（Vmax）の抑制を指しており、うつ病モデルではない",
+      "対象はモルモット心室組織であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 5918,
+    "usage": {
+      "prompt": 685,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-873",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の記載がなく、胎盤および肝臓へのエタノールの影響を調べた動物研究であるが、うつ病モデルに関する記述が全くない"
+    ],
+    "durationMs": 3251,
+    "usage": {
+      "prompt": 398,
+      "completion": 78,
+      "reasoning": 0,
+      "total": 476
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-874",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "タイトルおよび抄録に「うつ病」や動物モデルの記載がない"
+    ],
+    "durationMs": 2494,
+    "usage": {
+      "prompt": 405,
+      "completion": 54,
+      "reasoning": 0,
+      "total": 459
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-875",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3578,
+    "usage": {
+      "prompt": 1119,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 1214
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-876",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または心臓性うつ状態を指すのではなく、赤血球前駆細胞の抑制を意味しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5025,
+    "usage": {
+      "prompt": 645,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 779
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-877",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経活動の抑制（活動依存性抑制）を指しており、うつ病モデルではない",
+      "対象が分離神経（両生類およびヒト）であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 6508,
+    "usage": {
+      "prompt": 559,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 744
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-878",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病のin vivo動物モデルではなく、心臓のイオンチャネルに関する研究である",
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性があるが、本抄録ではそもそも「depression」という語が使用されていない"
+    ],
+    "durationMs": 3614,
+    "usage": {
+      "prompt": 869,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 962
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-879",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、猫の運動皮質における長期増強（LTP）のメカニズムに関する神経生理学的研究である"
+    ],
+    "durationMs": 4849,
+    "usage": {
+      "prompt": 743,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 878
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-880",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、細胞浮腫と神経興奮性に関する研究である。「depression」は本研究で「cortical spreading depression（皮質拡延性抑制）」の文脈で使われており、うつ病とは無関係である。"
+    ],
+    "durationMs": 5959,
+    "usage": {
+      "prompt": 783,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 949
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-881",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」や動物モデルに関する記述がなく、対象が不明であるが、タイトルから代謝や脂肪酸関連の研究と推測され、うつ病のin vivoモデルとは関連しないと判断される"
+    ],
+    "durationMs": 4953,
+    "usage": {
+      "prompt": 408,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 547
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-882",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒツジであり、うつ病（depression）ではなく循環抑制（cardiovascular depression）を指しているため、対象外"
+    ],
+    "durationMs": 4033,
+    "usage": {
+      "prompt": 608,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 715
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-883",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が「long-term depression (LTD)」という神経科学用語として使われており、うつ病（depression）の動物モデルに関する研究ではない",
+      "うつ病やその動物モデルについての記述が一切ない"
+    ],
+    "durationMs": 4847,
+    "usage": {
+      "prompt": 648,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 775
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-884",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルに関する研究ではなく、エタノールによるテストステロン生合成阻害に関するin vitro研究である"
+    ],
+    "durationMs": 5758,
+    "usage": {
+      "prompt": 591,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 749
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-885",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病の動物モデル研究であり、ヒト研究や呼吸・循環器系の抑制を意味する「depression」ではない"
+    ],
+    "durationMs": 6871,
+    "usage": {
+      "prompt": 784,
+      "completion": 201,
+      "reasoning": 0,
+      "total": 985
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-886",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が骨髄抑制（bone marrow depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4119,
+    "usage": {
+      "prompt": 710,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 808
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-887",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物モデルを用いたうつ病研究ではなく、コナカイガラムシの集団間の遺伝的分化に関する研究である。「depression」が「outbreeding depression」として使われているが、これはうつ病ではなく交配劣勢を指しており、対象外である。"
+    ],
+    "durationMs": 5472,
+    "usage": {
+      "prompt": 797,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 951
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-888",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない。GABAの取り込みと代謝に関する生化学的研究であり、うつ病の文脈が含まれていない。"
+    ],
+    "durationMs": 2769,
+    "usage": {
+      "prompt": 417,
+      "completion": 63,
+      "reasoning": 0,
+      "total": 480
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-889",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能低下（cardiac depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4676,
+    "usage": {
+      "prompt": 885,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 995
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-890",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気圧の低下（depression of the mucosa）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3748,
+    "usage": {
+      "prompt": 465,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 570
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-891",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2680,
+    "usage": {
+      "prompt": 414,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 467
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-892",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」が「spreading depression（拡張性抑制）」を指しており、うつ病モデルではない可能性が高い",
+      "動物実験かどうか不明だが、タイトルからうつ病のin vivoモデルとは判断できない",
+      "抄録がなく判断材料が不足しているため、感度を優先してもうつ病関連のエビデンスが極めて弱い"
+    ],
+    "durationMs": 5443,
+    "usage": {
+      "prompt": 407,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 558
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-893",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルに関する研究であり、抄録に「depressive symptoms」および「learned helplessness test」といったうつ病関連の評価が明記されているため"
+    ],
+    "durationMs": 5997,
+    "usage": {
+      "prompt": 730,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 897
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-894",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経生理学的なシナプスの抑制（depression of thalamocortical synapses）を指しており、うつ病（depression）ではない",
+      "動物実験かどうか明記されていないが、うつ病モデルではないため対象外"
+    ],
+    "durationMs": 5367,
+    "usage": {
+      "prompt": 450,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 592
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-895",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4012,
+    "usage": {
+      "prompt": 1090,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 1193
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-896",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4050,
+    "usage": {
+      "prompt": 707,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 808
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-897",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が胃排出抑制を指しており、うつ病モデルではない",
+      "対象が子牛であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4459,
+    "usage": {
+      "prompt": 836,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 945
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-898",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病の動物モデルに関するものではない"
+    ],
+    "durationMs": 3858,
+    "usage": {
+      "prompt": 690,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 792
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-899",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物モデルを用いたうつ病研究ではなく、Daphnia magna（ミジンコ）を用いた寄生感染と適応度に関する研究である。うつ病（depression）は一切言及されておらず、inbreeding depression（近交劣勢）が使われているが、これは精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5649,
+    "usage": {
+      "prompt": 695,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-900",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、うつ病を指しているか不明だが、抄録全体でうつ病モデルに関する記述がなく、脊髄損傷後の反射亢進（hyperreflexia）に関する研究である。"
+    ],
+    "durationMs": 4956,
+    "usage": {
+      "prompt": 781,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 916
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-901",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、前庭眼反射系の可塑性を調べた動物実験である。「depression」が出現しない上に、研究対象はうつ病とは無関係である。"
+    ],
+    "durationMs": 3360,
+    "usage": {
+      "prompt": 806,
+      "completion": 81,
+      "reasoning": 0,
+      "total": 887
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-902",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヤギにおけるメタン排出や瘤胃発酵に関する研究であり、うつ病（depression）のin vivoモデルに関する研究ではない。文中の'depression'はメタン生成菌（methanogens）の抑制を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5188,
+    "usage": {
+      "prompt": 803,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 950
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-903",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢神経系の抑制を指しており、うつ病モデルではない",
+      "対象が海洋哺乳類だが、うつ病のin vivoモデルとしての記述はなく、セレン中毒の症例報告である"
+    ],
+    "durationMs": 5131,
+    "usage": {
+      "prompt": 600,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 725
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-904",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「growth depression（成長抑制）」を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4091,
+    "usage": {
+      "prompt": 571,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 671
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-905",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性予測不能軽度ストレス（CUMS）モデルを用いたラットにおけるうつ病様行動の研究であり、生体内動物モデルのうつ病研究である"
+    ],
+    "durationMs": 6076,
+    "usage": {
+      "prompt": 700,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 862
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-906",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、シナプシン欠損マウスにおける長期増強（LTP）の研究であるため"
+    ],
+    "durationMs": 6836,
+    "usage": {
+      "prompt": 674,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 871
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-907",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、鶏胚由来の軟骨形成に関する研究である"
+    ],
+    "durationMs": 5915,
+    "usage": {
+      "prompt": 709,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 880
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-908",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究であり、in vivoのラット実験であるため"
+    ],
+    "durationMs": 5132,
+    "usage": {
+      "prompt": 969,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 1105
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-909",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから動物種としてウサギが使用されているが、うつ病モデルではなく、離断腸および心房の自発活動に関する薬理学的研究であり、うつ病（depression）の文脈が存在しない"
+    ],
+    "durationMs": 5136,
+    "usage": {
+      "prompt": 419,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 566
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-910",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、脳の拡張性抑制（spreading depression）を指しており、呼吸性アシドーシス/アルカローシス（hypocarbia）に関する研究であるため、対象外となる"
+    ],
+    "durationMs": 5858,
+    "usage": {
+      "prompt": 840,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 985
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-911",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、シナプス可塑性の一種である長期抑圧（long-term depression, LTD）を指しているため、対象外である。"
+    ],
+    "durationMs": 5958,
+    "usage": {
+      "prompt": 649,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 811
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-912",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象が躁病様行動（mania-like behavior）であり、うつ病モデルではない"
+    ],
+    "durationMs": 5635,
+    "usage": {
+      "prompt": 760,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-913",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression）を指しており、これは神経生理学的現象であり精神疾患モデルではない"
+    ],
+    "durationMs": 5220,
+    "usage": {
+      "prompt": 406,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 520
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-914",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経伝達の抑制を指しており、うつ病モデルではない。対象は呼吸・自律神経調節に関連する脳幹ニューロンの生理学的変化であり、うつ病のin vivo動物モデルではない。"
+    ],
+    "durationMs": 6803,
+    "usage": {
+      "prompt": 785,
+      "completion": 203,
+      "reasoning": 0,
+      "total": 988
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-915",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではないため除外"
+    ],
+    "durationMs": 3826,
+    "usage": {
+      "prompt": 693,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 795
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-916",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、霊長類における房水流量に関する研究である"
+    ],
+    "durationMs": 3517,
+    "usage": {
+      "prompt": 414,
+      "completion": 92,
+      "reasoning": 0,
+      "total": 506
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-917",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来の5-HT6受容体を用いたin vitro細胞実験であり、うつ病のin vivo動物モデルを対象とした研究ではない"
+    ],
+    "durationMs": 7157,
+    "usage": {
+      "prompt": 720,
+      "completion": 208,
+      "reasoning": 0,
+      "total": 928
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-918",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が長期抑圧（LTD）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3990,
+    "usage": {
+      "prompt": 616,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 722
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-919",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく皮質拡延性抑制（cortical spreading depression）を指しており、精神疾患モデルではない",
+      "対象は脳虚血や脳卒中の神経保護メカニズムに関する研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6625,
+    "usage": {
+      "prompt": 753,
+      "completion": 187,
+      "reasoning": 0,
+      "total": 940
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-920",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がウミウシ（Aplysia）の神経細胞であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "抄録中に「depression（うつ病）」という用語が一切出現しない"
+    ],
+    "durationMs": 3524,
+    "usage": {
+      "prompt": 738,
+      "completion": 84,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-921",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、腫瘍細胞の成長に関する研究である"
+    ],
+    "durationMs": 7137,
+    "usage": {
+      "prompt": 548,
+      "completion": 204,
+      "reasoning": 0,
+      "total": 752
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-922",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患が気管支喘息であり、うつ病（depression）の研究ではない。文中の'depression'は気道過剰反応性の抑制（depression on airway hyper-responsiveness）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5435,
+    "usage": {
+      "prompt": 776,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 923
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-923",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2862,
+    "usage": {
+      "prompt": 409,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-924",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「Depressant action」は神経活動の抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない可能性が高い",
+      "タイトルからでは対象がin vivo動物モデルかどうか不明だが、「depression」が呼吸・循環抑制などではなくうつ病を指している証拠もない"
+    ],
+    "durationMs": 5131,
+    "usage": {
+      "prompt": 410,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 546
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-925",
+    "label_included": 1,
+    "include_probability": 0.9,
+    "reasons": [
+      "タイトルに「psychodepressive effects」とあり、ベンゾジアゼピン系向精神薬の抑うつ効果を対象としている可能性が高い。ただし抄録がなく、動物実験かどうかは不明だが、感度を重視して含めるべき"
+    ],
+    "durationMs": 4854,
+    "usage": {
+      "prompt": 411,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 539
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-926",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "強制泳泳試験（FST）および尾懸垂試験（TST）を用いたマウスを用いたin vivoモデルでの抗うつ作用の評価が行われており、動物実験であることが明確"
+    ],
+    "durationMs": 6152,
+    "usage": {
+      "prompt": 649,
+      "completion": 180,
+      "reasoning": 0,
+      "total": 829
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-927",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関する動物実験であり、うつ病（depression）は精神疾患として扱われている"
+    ],
+    "durationMs": 6308,
+    "usage": {
+      "prompt": 904,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 1082
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-928",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、ラットの交尾行動（ロードーシス反応）に関する研究である"
+    ],
+    "durationMs": 5361,
+    "usage": {
+      "prompt": 601,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 757
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-929",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depress」が含まれるが、文脈からは免疫抑制など生理的抑制を指している可能性が高く、うつ病の動物モデルに関する研究とは考えにくい。抄録がなく、動物研究か人間研究か判断できないが、タイトルから人間のストレス・グリーフに関する議論と推測され、うつ病のin vivo動物モデルとは関連が薄い。"
+    ],
+    "durationMs": 5998,
+    "usage": {
+      "prompt": 400,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 559
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-930",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、代謝経路に関する生化学的研究である"
+    ],
+    "durationMs": 2113,
+    "usage": {
+      "prompt": 423,
+      "completion": 46,
+      "reasoning": 0,
+      "total": 469
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-931",
+    "label_included": 0,
+    "include_probability": 0.3,
+    "reasons": [
+      "うつ病に関する言及があるが、動物モデルを用いたうつ病の研究ではなく、神経解剖学的観察に焦点を当てており、うつ病の病態モデルや行動評価が含まれていない"
+    ],
+    "durationMs": 4419,
+    "usage": {
+      "prompt": 954,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 1075
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-932",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした乳がん治療に関する研究であり、うつ病のin vivo動物モデルに関する記述がない"
+    ],
+    "durationMs": 3917,
+    "usage": {
+      "prompt": 751,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 857
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-933",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（テトラベンアジンモデル）を用いたin vivo研究であり、対象が動物であることが明記されている"
+    ],
+    "durationMs": 5695,
+    "usage": {
+      "prompt": 558,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 703
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-934",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓のバロリフレックス抑制（cardiac baroreflex gainの低下）を指しており、うつ病モデルではない。対象は高血圧ラットであり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 4734,
+    "usage": {
+      "prompt": 774,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 903
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-935",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫機能の抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3733,
+    "usage": {
+      "prompt": 437,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 538
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-936",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、脳スライスを用いたin vitro実験である",
+      "「depression」という語は本抄録内で神経機能の抑制を指しており、うつ病を意味しない"
+    ],
+    "durationMs": 6925,
+    "usage": {
+      "prompt": 732,
+      "completion": 187,
+      "reasoning": 0,
+      "total": 919
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-937",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、水銀の分布に関する研究である"
+    ],
+    "durationMs": 4324,
+    "usage": {
+      "prompt": 422,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-938",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来細胞（HeLa細胞、PC12細胞）を用いたin vitro実験であり、in vivo動物モデルではない",
+      "うつ病（depression）に関する研究ではなく、DNA損傷による転写阻害の検出法の開発が目的"
+    ],
+    "durationMs": 8040,
+    "usage": {
+      "prompt": 794,
+      "completion": 198,
+      "reasoning": 0,
+      "total": 992
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-939",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3853,
+    "usage": {
+      "prompt": 548,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 641
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-940",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした強迫性障害（OCD）の臨床試験であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4711,
+    "usage": {
+      "prompt": 671,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 803
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-941",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「rat model of depressive disorder」とあり、うつ病のin vivo動物モデルに関する研究であることが明確"
+    ],
+    "durationMs": 3572,
+    "usage": {
+      "prompt": 416,
+      "completion": 92,
+      "reasoning": 0,
+      "total": 508
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-942",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が新規承認医薬品の非臨床研究の出版パターンに関するレビューであり、うつ病のin vivoモデルを対象とした動物実験研究ではない"
+    ],
+    "durationMs": 5100,
+    "usage": {
+      "prompt": 749,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 884
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-943",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や運動抑制などうつ病以外の文脈で使用されており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4410,
+    "usage": {
+      "prompt": 603,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 722
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-944",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ヒトではなくアフリカワラビー（Arvicanthis niloticus）を用いた動物実験であり、うつ病の動物モデルに関する研究である。"
+    ],
+    "durationMs": 5211,
+    "usage": {
+      "prompt": 774,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-945",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「行動」とあるが、うつ病の動物モデルに関する記述が明確でなく、抄録がないため判断不能"
+    ],
+    "durationMs": 3836,
+    "usage": {
+      "prompt": 399,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 501
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-946",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様行動の動物実験であり、対象とするin vivoモデルに該当する"
+    ],
+    "durationMs": 5814,
+    "usage": {
+      "prompt": 773,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 928
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-947",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がウサギであり、うつ病のin vivoモデルに関する研究ではない可能性が高い。また、タイトルからうつ病（depression）ではなく体温調節（hyperthermia）に関する研究であることが示唆される。"
+    ],
+    "durationMs": 4621,
+    "usage": {
+      "prompt": 413,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 537
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-948",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性抑うつや中枢神経系の機能抑制を指しており、うつ病モデルではない",
+      "in vivoのうつ病動物モデルを対象とした研究ではない"
+    ],
+    "durationMs": 6956,
+    "usage": {
+      "prompt": 782,
+      "completion": 207,
+      "reasoning": 0,
+      "total": 989
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-949",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する記述がない",
+      "対象がラットではあるが、メチルフェニデート誘発性神経障害に関する研究であり、うつ病モデルとは明確に異なる"
+    ],
+    "durationMs": 5214,
+    "usage": {
+      "prompt": 407,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 550
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-950",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は臨床症状としての抑うつではなく、一般的な病態（元気消失）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4183,
+    "usage": {
+      "prompt": 810,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-951",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトおよび動物を含むレビューであり、うつ病のin vivo動物モデルを対象とした研究ではない。また、「depression」がうつ病を指している記述が抄録に見られない。"
+    ],
+    "durationMs": 4631,
+    "usage": {
+      "prompt": 604,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 734
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-952",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いた慢性予測不能軽度ストレス（CUMS）モデルによるうつ病関連行動の評価が行われており、in vivo動物モデル研究である"
+    ],
+    "durationMs": 7596,
+    "usage": {
+      "prompt": 761,
+      "completion": 230,
+      "reasoning": 0,
+      "total": 991
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-953",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が感覚伝達の抑制（respiratory depressionやcardiac depressionと同様の生理的抑制）を指しており、うつ病モデルではない",
+      "in vitro 脳幹標本を用いた研究であり、in vivo うつ病モデルではない"
+    ],
+    "durationMs": 6646,
+    "usage": {
+      "prompt": 620,
+      "completion": 192,
+      "reasoning": 0,
+      "total": 812
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-954",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が腸管運動の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3662,
+    "usage": {
+      "prompt": 668,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 761
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-955",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢神経系の抑制（CNS depression）を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病のin vivoモデルに関する記述が一切ない"
+    ],
+    "durationMs": 4626,
+    "usage": {
+      "prompt": 871,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 999
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-956",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であるという明確な根拠がない",
+      "抄録が存在せず、研究内容の判断が困難であるが、タイトルから推測される内容は神経化学的メカニズムに関するもので、うつ病モデルとは関連が薄い"
+    ],
+    "durationMs": 3812,
+    "usage": {
+      "prompt": 417,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 520
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-957",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や代謝抑制を指しており、うつ病モデルではない",
+      "うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4350,
+    "usage": {
+      "prompt": 645,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 766
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-958",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が血液学的パラメータの低下を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3620,
+    "usage": {
+      "prompt": 535,
+      "completion": 94,
+      "reasoning": 0,
+      "total": 629
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-959",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depressive reaction」とあるが、これは低酸素による中枢神経系の抑制反応であり、うつ病モデルではない",
+      "うつ病（depression）ではなく、呼吸性または中枢神経の抑制状態を指している",
+      "動物実験ではあるが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4954,
+    "usage": {
+      "prompt": 640,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 780
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-960",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が炎症性サイトカイン（TNF-alpha）の抑制を指しており、うつ病モデルではない",
+      "研究はLPS誘発性ショックやフィブリノリシスに関するもので、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5007,
+    "usage": {
+      "prompt": 736,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 872
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-961",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、心筋虚血および造影剤の影響を調べた犬を用いた心血管研究である。「depression」はSTセグメントの低下（心電図所見）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 7108,
+    "usage": {
+      "prompt": 584,
+      "completion": 212,
+      "reasoning": 0,
+      "total": 796
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-962",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が脂肪消化吸収の抑制を指しており、うつ病（depression）の動物モデルではない",
+      "対象はラットだが、うつ病の評価やモデル化に関する記述が全くない"
+    ],
+    "durationMs": 4566,
+    "usage": {
+      "prompt": 571,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 694
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-963",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなく、培養ヒトまたは動物由来の神経細胞を用いたin vitro実験である",
+      "「depression」が「synaptic depression（シナプス疲労）」を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 6411,
+    "usage": {
+      "prompt": 705,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 890
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-964",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が脳構造の興奮性低下を指しており、うつ病モデルではない可能性が高い"
+    ],
+    "durationMs": 3774,
+    "usage": {
+      "prompt": 482,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 585
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-965",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓の活動電位の頻度依存性抑制（心臓の機能的抑制）を指しており、うつ病モデルではない",
+      "対象がラットの右心房組織であり、in vivoうつ病モデルではない"
+    ],
+    "durationMs": 6774,
+    "usage": {
+      "prompt": 566,
+      "completion": 196,
+      "reasoning": 0,
+      "total": 762
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-966",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究は糖尿病性神経障害を対象としており、うつ病のin vivoモデルではない。H波抑制（H-wave depression）は神経生理学的指標であり、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 4774,
+    "usage": {
+      "prompt": 787,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-967",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は血中甲状腺ホルモン濃度の低下を指しており、うつ病モデルではない",
+      "対象はシーランプ（海生脊椎動物）の自然変態過程であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5309,
+    "usage": {
+      "prompt": 856,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 998
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-968",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（in vivo動物モデル）であり、うつ病様行動を評価している"
+    ],
+    "durationMs": 5334,
+    "usage": {
+      "prompt": 705,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 857
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-969",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから動物モデルを用いたうつ病研究であることを示す情報がなく、むしろ人間の文化的多様性に関する研究と推測されるため"
+    ],
+    "durationMs": 4157,
+    "usage": {
+      "prompt": 402,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 511
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-970",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指しているため、対象外である"
+    ],
+    "durationMs": 5484,
+    "usage": {
+      "prompt": 615,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 773
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-971",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指しており、うつ病モデルではない",
+      "in vivoのうつ病モデルに関する研究ではなく、脳スライスを用いたin vitro実験である"
+    ],
+    "durationMs": 6291,
+    "usage": {
+      "prompt": 550,
+      "completion": 183,
+      "reasoning": 0,
+      "total": 733
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-972",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした臨床試験（フェーズIII）に関する記述であり、in vivo動物モデルの研究ではない"
+    ],
+    "durationMs": 4170,
+    "usage": {
+      "prompt": 463,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 565
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-973",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "タイトルおよび抄録に「うつ病」の記載がなく、代謝研究である"
+    ],
+    "durationMs": 2676,
+    "usage": {
+      "prompt": 440,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 497
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-974",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoのラットを用いたうつ病モデルに関する動物実験であり、対象とするうつ病は精神疾患としてのうつ病である"
+    ],
+    "durationMs": 6263,
+    "usage": {
+      "prompt": 707,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-975",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、神経遮断薬による口運動の副作用を調べた動物実験である。「depression」が出現する文脈は運動の抑制（depression of OMs）であり、うつ病を指していない。"
+    ],
+    "durationMs": 5447,
+    "usage": {
+      "prompt": 749,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 901
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-976",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はグルタチオンS-トランスフェラーゼ活性の低下を指しており、うつ病モデルではない",
+      "対象はラットだが、うつ病のin vivoモデルに関する研究ではない",
+      "研究目的は肝発がんであり、精神疾患のモデルではない"
+    ],
+    "durationMs": 5327,
+    "usage": {
+      "prompt": 726,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-977",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がマウスを用いたうつ病様行動のin vivo動物モデルであり、人間研究ではなく、呼吸・心臓抑制などの他の「depression」とは無関係である"
+    ],
+    "durationMs": 6432,
+    "usage": {
+      "prompt": 771,
+      "completion": 184,
+      "reasoning": 0,
+      "total": 955
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-978",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がin vivo動物モデルを用いたうつ病研究であり、ヒト研究や呼吸抑制などを指す「depression」ではない"
+    ],
+    "durationMs": 8270,
+    "usage": {
+      "prompt": 836,
+      "completion": 246,
+      "reasoning": 0,
+      "total": 1082
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-979",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経活動の抑制（depression of glutamate-regulated...）を指しており、うつ病モデルではない",
+      "対象は培養ラット視床下部ニューロンであり、うつ病のin vivo動物モデルではない",
+      "うつ病（depression）に関する研究ではなく、ドーパミンとグルタミン酸の神経生理学的相互作用の研究である"
+    ],
+    "durationMs": 7382,
+    "usage": {
+      "prompt": 1210,
+      "completion": 216,
+      "reasoning": 0,
+      "total": 1426
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-980",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトまたは動物のうつ病モデルに関する研究ではなく、消化管におけるセロトニン制御機構に焦点を当てている",
+      "うつ病（depression）が呼吸抑制や心機能抑制などを指していないか確認できるが、そもそもうつ病自体が主題ではない"
+    ],
+    "durationMs": 5116,
+    "usage": {
+      "prompt": 581,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 723
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-981",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指しており、うつ病モデルではない。対象はラットだが、感情・疼痛ストレスによる脂質代謝異常の研究であり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 6296,
+    "usage": {
+      "prompt": 647,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 825
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-982",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「spreading depression（拡張性抑制）」は神経生理学的現象であり、うつ病（depression）の動物モデルではない。本研究は脳血流変化を対象としており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5941,
+    "usage": {
+      "prompt": 622,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 796
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-983",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」とあるが、これは「cortical spreading depression（皮質拡延性抑制）」を指しており、うつ病モデルではない",
+      "対象はマウス脳組織だが、うつ病のin vivoモデルではなく、片頭痛などの神経疾患モデルである"
+    ],
+    "durationMs": 5702,
+    "usage": {
+      "prompt": 532,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 673
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-984",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルにうつ病や動物モデルに関する記述がなく、血小板凝集阻害剤に関する研究であるため、対象外と判断される"
+    ],
+    "durationMs": 3949,
+    "usage": {
+      "prompt": 402,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 512
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-985",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなくin vitroのラット脳スライスを用いた実験である",
+      "うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4329,
+    "usage": {
+      "prompt": 570,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 681
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-986",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4500,
+    "usage": {
+      "prompt": 735,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 847
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-987",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が運動抑制（locomotor depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4623,
+    "usage": {
+      "prompt": 702,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 827
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-988",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢神経、消化管、心血管機能の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4333,
+    "usage": {
+      "prompt": 623,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 730
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-989",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 5273,
+    "usage": {
+      "prompt": 533,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 677
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-990",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "fosBノックアウトマウスにおいて抑うつ様行動が観察されており、うつ病のin vivo動物モデルを用いた研究である"
+    ],
+    "durationMs": 4462,
+    "usage": {
+      "prompt": 856,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 970
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-991",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経科学における長期抑圧（long-term depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4289,
+    "usage": {
+      "prompt": 643,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 746
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-992",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する動物実験であり、うつ病（respiratory depression等ではない）を対象としている"
+    ],
+    "durationMs": 6951,
+    "usage": {
+      "prompt": 645,
+      "completion": 207,
+      "reasoning": 0,
+      "total": 852
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-993",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経代謝の抑制（neuronal metabolic depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5748,
+    "usage": {
+      "prompt": 719,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 886
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-994",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は成長抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4893,
+    "usage": {
+      "prompt": 552,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 666
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-995",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究であり、ヒト研究ではない。うつ病は呼吸抑制などを指していない。"
+    ],
+    "durationMs": 5625,
+    "usage": {
+      "prompt": 641,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 796
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-996",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく皮質拡張性抑制（cortical spreading depression）を指しており、呼吸抑制や心機能抑制と同様に精神疾患としてのうつ病とは無関係である"
+    ],
+    "durationMs": 5882,
+    "usage": {
+      "prompt": 747,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 914
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-997",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2210,
+    "usage": {
+      "prompt": 406,
+      "completion": 49,
+      "reasoning": 0,
+      "total": 455
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-998",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression）を指しており、これは神経生理学的現象であり精神疾患ではない"
+    ],
+    "durationMs": 5606,
+    "usage": {
+      "prompt": 885,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 1047
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-999",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、低酸素症による海馬神経細胞の電流変化を調べた研究である"
+    ],
+    "durationMs": 5845,
+    "usage": {
+      "prompt": 806,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 967
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1000",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が「long-term depression（長期抑圧）」という神経可塑性の用語として使われており、うつ病（depression）の動物モデルではない。うつ病に関する記述は一切ない。"
+    ],
+    "durationMs": 5242,
+    "usage": {
+      "prompt": 593,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 730
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1001",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病関連のin vivo研究であり、うつ病（depression）を精神疾患として扱っている"
+    ],
+    "durationMs": 6140,
+    "usage": {
+      "prompt": 752,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 927
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1002",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される。また、「pulmonary circulation（肺循環）」に関する研究であり、呼吸抑制などの生理的抑制を指す可能性があるが、そもそも「depression」という語が使用されていない。"
+    ],
+    "durationMs": 5789,
+    "usage": {
+      "prompt": 408,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 558
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1003",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、エタノールとGABA作動性抑制に関する神経生理学的研究である"
+    ],
+    "durationMs": 4148,
+    "usage": {
+      "prompt": 487,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 586
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1004",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」とは呼吸抑制や循環抑制などの生理的抑制を指しており、うつ病モデルではない",
+      "対象は家禽（ガチョウ）における細菌感染症のアウトブレイクで、うつ病のin vivoモデル研究ではない"
+    ],
+    "durationMs": 5193,
+    "usage": {
+      "prompt": 661,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 797
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1005",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "糖尿病ラットを用いたうつ病様行動に関するin vivo動物実験であり、対象がヒトではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 8108,
+    "usage": {
+      "prompt": 760,
+      "completion": 242,
+      "reasoning": 0,
+      "total": 1002
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1006",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（metabolic rate depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 3745,
+    "usage": {
+      "prompt": 703,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 799
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1007",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "抄録が存在せず、研究内容の判断ができないが、タイトルからin vivoモデルやうつ病関連の示唆が得られないため除外"
+    ],
+    "durationMs": 3998,
+    "usage": {
+      "prompt": 404,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 497
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1008",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や代謝抑制などうつ病以外の文脈で使用されており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4240,
+    "usage": {
+      "prompt": 786,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 904
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1009",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスおよびラットを用いたうつ病モデルに関するin vivo動物実験であり、対象がヒトではなく、呼吸抑制などの他の意味での「depression」ではないため"
+    ],
+    "durationMs": 8006,
+    "usage": {
+      "prompt": 794,
+      "completion": 237,
+      "reasoning": 0,
+      "total": 1031
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1010",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がうつ病ではなく、脳虚血（脳卒中）に関する研究である"
+    ],
+    "durationMs": 5250,
+    "usage": {
+      "prompt": 735,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 878
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1011",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」や「depression」に関する記述が含まれておらず、動物モデルを用いたうつ病研究であることを示す根拠がない"
+    ],
+    "durationMs": 2900,
+    "usage": {
+      "prompt": 404,
+      "completion": 67,
+      "reasoning": 0,
+      "total": 471
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1012",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3541,
+    "usage": {
+      "prompt": 558,
+      "completion": 86,
+      "reasoning": 0,
+      "total": 644
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1013",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない",
+      "「depression」が呼吸抑制（respiratory depression）を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 4228,
+    "usage": {
+      "prompt": 698,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 812
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1014",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、小脳核ニューロンにおけるGABA受容体の動態に関する基礎神経科学的研究である"
+    ],
+    "durationMs": 5031,
+    "usage": {
+      "prompt": 711,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1015",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivo動物モデル（ラット）を用いたうつ病関連研究であり、対象とするうつ病は精神疾患としてのうつ病である"
+    ],
+    "durationMs": 5366,
+    "usage": {
+      "prompt": 724,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 877
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1016",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2569,
+    "usage": {
+      "prompt": 415,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 468
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1017",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器系または代謝機能の抑制（complex I activityの低下）を指しており、うつ病モデルではない",
+      "in vivoのうつ病動物モデルに関する研究ではない",
+      "対象はウシ肺動脈内皮細胞を用いたin vitro実験である"
+    ],
+    "durationMs": 5712,
+    "usage": {
+      "prompt": 873,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 1031
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1018",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "研究対象がモルモットの膀胱であり、うつ病とは無関係"
+    ],
+    "durationMs": 4185,
+    "usage": {
+      "prompt": 405,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 519
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1019",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が長期抑圧（LTD: long-term depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4570,
+    "usage": {
+      "prompt": 726,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 845
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1020",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（施設入所高齢者）であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 5478,
+    "usage": {
+      "prompt": 710,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1021",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病の動物モデルに関する記述が見られず、研究対象が副腎ミトコンドリアのシトクロムP-450であるため、うつ病の研究とは関連しないと判断される"
+    ],
+    "durationMs": 5129,
+    "usage": {
+      "prompt": 413,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 557
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1022",
+    "label_included": 0,
+    "include_probability": 0.7,
+    "reasons": [
+      "タイトルに「animal experiments（動物実験）」と記載されており、うつ病のin vivoモデルの可能性があるが、抄録がなく、うつ病が精神疾患として扱われているか不明なため"
+    ],
+    "durationMs": 4585,
+    "usage": {
+      "prompt": 436,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 554
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1023",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制など、うつ病以外の文脈で使用されている",
+      "対象が動物のうつ病モデルではなく、亀の心臓の代謝に関する研究"
+    ],
+    "durationMs": 5765,
+    "usage": {
+      "prompt": 592,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 757
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1024",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「respiratory depression」や「cardiac depression」ではなく、うつ病を指しているか確認できないが、抄録中の 'depresses' は腎機能の抑制を意味しており、うつ病モデルの動物実験ではないと判断される。"
+    ],
+    "durationMs": 5599,
+    "usage": {
+      "prompt": 780,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 939
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1025",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が鶏の飼料評価であり、うつ病のin vivoモデルに関する研究ではない",
+      "「depression」は体重増加や飼料効率の低下を指しており、精神疾患としてのうつ病ではない"
+    ],
+    "durationMs": 4729,
+    "usage": {
+      "prompt": 766,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 899
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1026",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象が神経芽腫とグリオーマのハイブリッド細胞であり、in vivoのうつ病モデルではない",
+      "「depression」がカルシウム電流の抑制（depressed the ICa）を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 6620,
+    "usage": {
+      "prompt": 560,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 757
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1027",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、麻酔薬エトミデートの運動誘発電位への影響を調べた研究である",
+      "「depression」は脊髄機能の抑制（depression of the spinal cord）を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 5796,
+    "usage": {
+      "prompt": 995,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 1163
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1028",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトであり、動物実験ではないため除外"
+    ],
+    "durationMs": 4683,
+    "usage": {
+      "prompt": 850,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 972
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1029",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される",
+      "タイトルから哺乳類の乳腺におけるDNA合成に関するin vitro研究と推測され、対象外である"
+    ],
+    "durationMs": 4881,
+    "usage": {
+      "prompt": 401,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 528
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1030",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivo動物実験（ラット）でうつ病関連の神経伝達機構を調査しているため"
+    ],
+    "durationMs": 5201,
+    "usage": {
+      "prompt": 1016,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 1163
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1031",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病を含む精神疾患患者の前頭前皮質組織を分析しているため、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 4786,
+    "usage": {
+      "prompt": 801,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 936
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1032",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「Experimental」とあるが、動物実験か人間研究か不明であり、抄録が存在しないため判断できない"
+    ],
+    "durationMs": 3607,
+    "usage": {
+      "prompt": 403,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 496
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1033",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（ラット）を用いた研究であり、行動性絶望テスト（強制泳ぎテスト）でうつ様行動を評価している。人間の研究ではなく、呼吸抑制などの他の「depression」とは無関係。"
+    ],
+    "durationMs": 6146,
+    "usage": {
+      "prompt": 665,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 835
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1034",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（マウス）を用いた研究であり、ヒト研究のみではないため包含対象"
+    ],
+    "durationMs": 4144,
+    "usage": {
+      "prompt": 590,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 691
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1035",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、学習・記憶およびシナプス可塑性に焦点を当てた研究である"
+    ],
+    "durationMs": 2960,
+    "usage": {
+      "prompt": 818,
+      "completion": 61,
+      "reasoning": 0,
+      "total": 879
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1036",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がサメ（epaulette shark）であり、うつ病（depression）ではなく低酸素・無酸素状態における代謝抑制（metabolic depression）に関する研究である。うつ病のin vivo動物モデルに関する研究ではない。"
+    ],
+    "durationMs": 5092,
+    "usage": {
+      "prompt": 888,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 1016
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1037",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデル（CUMS）に関する動物実験であり、うつ病様行動およびその機序を検討している"
+    ],
+    "durationMs": 6055,
+    "usage": {
+      "prompt": 751,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 926
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1038",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした多発性硬化症の臨床試験であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4490,
+    "usage": {
+      "prompt": 869,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 976
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1039",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「in vitro」と明記されており、in vivo動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 3306,
+    "usage": {
+      "prompt": 424,
+      "completion": 85,
+      "reasoning": 0,
+      "total": 509
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1040",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトを含む臨床研究および承認情報に焦点を当てており、うつ病のin vivo動物モデルに関する記述がない"
+    ],
+    "durationMs": 6604,
+    "usage": {
+      "prompt": 709,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 900
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1041",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動に関するin vivo研究であり、対象が動物モデルであるため"
+    ],
+    "durationMs": 6048,
+    "usage": {
+      "prompt": 750,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 915
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1042",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や心機能抑制などの生理学的抑制を指しており、うつ病モデルではない",
+      "研究対象がカエルの神経筋標本であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 4778,
+    "usage": {
+      "prompt": 660,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 793
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1043",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が尿浸透圧およびエリスロポエチン産生の低下を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5338,
+    "usage": {
+      "prompt": 701,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1044",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「CNS depression」とあるが、これは中枢神経抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない。対象はヒトではなく霊長類だが、うつ病モデルではないため除外対象。"
+    ],
+    "durationMs": 4910,
+    "usage": {
+      "prompt": 608,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 735
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1045",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病を指しておらず、マクロファージの抑制（suppression）を意味している",
+      "研究対象は急性肝炎であり、うつ病モデルではない",
+      "対象はラットだが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5865,
+    "usage": {
+      "prompt": 584,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 755
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1046",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、ラット脳由来受容体を用いたin vitro結合アッセイのみが記載されている"
+    ],
+    "durationMs": 5499,
+    "usage": {
+      "prompt": 764,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 920
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1047",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来のサンプル（血小板、死後脳、前頭前皮質スライス）を対象としており、in vivo動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 7719,
+    "usage": {
+      "prompt": 1082,
+      "completion": 230,
+      "reasoning": 0,
+      "total": 1312
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1048",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "対象がウミウシ（Aplysia）であり、うつ病のin vivoモデルではない。また、「depression」は神経細胞の興奮性低下を指しており、うつ病とは無関係。"
+    ],
+    "durationMs": 5398,
+    "usage": {
+      "prompt": 624,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 762
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1049",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性があるが、本抄録では「depression of hepatic cytochrome P-450」とあり、うつ病モデルではないと判断される。また、うつ病に関連する行動評価やモデルの記述が全くない。"
+    ],
+    "durationMs": 5350,
+    "usage": {
+      "prompt": 795,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 946
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1050",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経科学における長期抑圧（long-term depression, LTD）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5554,
+    "usage": {
+      "prompt": 680,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 828
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1051",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」の記載がなく、研究対象が肝臓の代謝であり、うつ病の動物モデルに関するものではないと判断される"
+    ],
+    "durationMs": 3090,
+    "usage": {
+      "prompt": 411,
+      "completion": 72,
+      "reasoning": 0,
+      "total": 483
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1052",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 4114,
+    "usage": {
+      "prompt": 511,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 609
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1053",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルを用いた研究であり、ヒト研究や呼吸・心臓の抑制を意味する「depression」ではない"
+    ],
+    "durationMs": 7515,
+    "usage": {
+      "prompt": 676,
+      "completion": 225,
+      "reasoning": 0,
+      "total": 901
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1054",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデル研究であり、動物実験であることが明確"
+    ],
+    "durationMs": 5683,
+    "usage": {
+      "prompt": 866,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 1029
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1055",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」または動物モデルに関する記述がなく、腎臓および副甲状腺ホルモンの代謝に関する研究と推測されるため"
+    ],
+    "durationMs": 2691,
+    "usage": {
+      "prompt": 396,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 461
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1056",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "レセルピン処理マウスを用いたうつ病のin vivo動物モデル研究であり、対象が動物実験で、うつ病（精神疾患）に関連していると判断される"
+    ],
+    "durationMs": 5843,
+    "usage": {
+      "prompt": 1024,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 1192
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1057",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がポニー（動物）ではあるが、「depression」が抑うつではなく、一般的な臨床症状（元気消失など）として用いられており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4588,
+    "usage": {
+      "prompt": 574,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 703
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1058",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ニコチン受容体と長期増強（LTP）に関する神経生理学的研究である。「depression」という語は神経活動の一時的抑制を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 5339,
+    "usage": {
+      "prompt": 759,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 907
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1059",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がシナプス機能の文脈（短期シナプス抑性）で使用されており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 5033,
+    "usage": {
+      "prompt": 685,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1060",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「melancholia（メランコリア）」とあるが、これは人間のうつ病を指しており、動物モデルに関する記述がない",
+      "タイトルから人間の症例（case of melancholia）と明確に読み取れるため、動物研究ではない"
+    ],
+    "durationMs": 4890,
+    "usage": {
+      "prompt": 405,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1061",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「CNS depressive agents」は中枢神経抑制作用を指しており、うつ病（depression）の動物モデルを対象とした研究ではない可能性が高い"
+    ],
+    "durationMs": 5108,
+    "usage": {
+      "prompt": 537,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 684
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1062",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が甲状腺ホルモン低下を指しており、うつ病モデルではない",
+      "研究対象はヒナであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4176,
+    "usage": {
+      "prompt": 518,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 626
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1063",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivo動物モデルのうつ病研究ではなく、in vitroのミトコンドリア代謝に関する研究である",
+      "「depression」が「respiratory depression」や「cardiac depression」と同様に代謝抑制を意味しており、うつ病を指していない"
+    ],
+    "durationMs": 6580,
+    "usage": {
+      "prompt": 544,
+      "completion": 173,
+      "reasoning": 0,
+      "total": 717
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1064",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、抄録が存在しないため、うつ病の動物モデルに関する研究かどうか判断できない"
+    ],
+    "durationMs": 2693,
+    "usage": {
+      "prompt": 411,
+      "completion": 61,
+      "reasoning": 0,
+      "total": 472
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1065",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、アルコール誘発性睡眠時間に関する研究である"
+    ],
+    "durationMs": 3901,
+    "usage": {
+      "prompt": 403,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 503
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1066",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」や「depression」の記載がなく、動物モデルを用いたうつ病研究であることを示す根拠がない"
+    ],
+    "durationMs": 3114,
+    "usage": {
+      "prompt": 419,
+      "completion": 64,
+      "reasoning": 0,
+      "total": 483
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1067",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋機能の低下（心臓の抑制）を指しており、うつ病の動物モデルではない",
+      "対象は羊（in vivo）だが、うつ病ではなく循環器系の薬理学的影響を評価している研究"
+    ],
+    "durationMs": 5177,
+    "usage": {
+      "prompt": 775,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 924
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1068",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経科学における短期シナプス抑制（short term synaptic depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3981,
+    "usage": {
+      "prompt": 572,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 679
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1069",
+    "label_included": 0,
+    "include_probability": 0.9,
+    "reasons": [
+      "タイトルに「rat brain」とあり、in vivo動物モデル（ラット）を使用している可能性が高いが、抄録がなく行動学的評価やうつ病モデルの使用が明確でないため、確定には全文確認が必要"
+    ],
+    "durationMs": 4351,
+    "usage": {
+      "prompt": 450,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 569
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1070",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が悪性高熱症感受性筋肉を用いたin vitro実験であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5673,
+    "usage": {
+      "prompt": 595,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 750
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1071",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデルに関する研究であり、in vivoモデルの使用が明確である"
+    ],
+    "durationMs": 4137,
+    "usage": {
+      "prompt": 558,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 670
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1072",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから「depression（うつ病）」に関する内容が確認できず、むしろ白血病細胞の薬剤耐性に関する研究と判断される"
+    ],
+    "durationMs": 4694,
+    "usage": {
+      "prompt": 414,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 543
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1073",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "セロトニン輸送体ノックアウトマウスを用いたうつ病モデルのin vivo動物研究であり、対象とするうつ病（気分障害）に関する評価を行っている"
+    ],
+    "durationMs": 7413,
+    "usage": {
+      "prompt": 580,
+      "completion": 209,
+      "reasoning": 0,
+      "total": 789
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1074",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」や「うつ病」に関する明確な記載がなく、動物モデルを使用しているか不明であるが、薬理学的研究であるため、うつ病の動物モデルに関連している可能性がある。抄録が存在しないため、判断に不確実性がある。"
+    ],
+    "durationMs": 3973,
+    "usage": {
+      "prompt": 415,
+      "completion": 92,
+      "reasoning": 0,
+      "total": 507
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1075",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、脳内の「拡大性抑制（spreading depression）」を指しており、呼吸抑制や心機能抑制と同様に精神疾患としてのうつ病とは無関係である"
+    ],
+    "durationMs": 5542,
+    "usage": {
+      "prompt": 727,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 886
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1076",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "Balb/cマウスを用いたうつ病のin vivoモデルに関する動物実験であり、ヒト研究ではない。うつ病は精神疾患として明確に記載されている。"
+    ],
+    "durationMs": 6206,
+    "usage": {
+      "prompt": 639,
+      "completion": 183,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1077",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2495,
+    "usage": {
+      "prompt": 403,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 456
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1078",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2348,
+    "usage": {
+      "prompt": 403,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 456
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1079",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、モルモット精管におけるノルアドレナリン放出と機械的反応に関する研究である"
+    ],
+    "durationMs": 4131,
+    "usage": {
+      "prompt": 411,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 514
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1080",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的現象（シナプス伝達の抑制）を指しており、うつ病（depression as a mood disorder）の動物モデルではない"
+    ],
+    "durationMs": 4323,
+    "usage": {
+      "prompt": 1026,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 1143
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1081",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病の前臨床モデルに関する研究であり、in vivo動物実験であるため"
+    ],
+    "durationMs": 5625,
+    "usage": {
+      "prompt": 753,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 912
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1082",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく動物（羊）であるが、研究目的はうつ病モデルではなく、オピオイドの神経毒性評価であり、「depression」は呼吸抑制（respiratory depression）を指している"
+    ],
+    "durationMs": 5004,
+    "usage": {
+      "prompt": 969,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 1107
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1083",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病の動物モデルに関する記述が確認できない",
+      "研究対象がウサギ精子の代謝であり、うつ病とは無関係である"
+    ],
+    "durationMs": 4827,
+    "usage": {
+      "prompt": 409,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 537
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1084",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がin vivo動物モデル（Pitx3欠損マウス）であり、うつ病関連行動を評価している"
+    ],
+    "durationMs": 6243,
+    "usage": {
+      "prompt": 676,
+      "completion": 183,
+      "reasoning": 0,
+      "total": 859
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1085",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅覚球摘出ラットを用いたうつ病のin vivo動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑圧などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 4370,
+    "usage": {
+      "prompt": 669,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 785
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1086",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸・循環器系などの生理的抑制（血漿蛋白の低下）を指しており、うつ病モデルではない",
+      "対象が七面鳥のヒナであり、うつ病のin vivoモデルとして使用されていない"
+    ],
+    "durationMs": 5670,
+    "usage": {
+      "prompt": 728,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 877
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1087",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究はin vitro（試験管内）モデルを使用しており、in vivo（生体内）モデルではないため除外される"
+    ],
+    "durationMs": 4404,
+    "usage": {
+      "prompt": 757,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 873
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1088",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、犬を用いた血小板凝集および脂質レベルに関する研究である"
+    ],
+    "durationMs": 7558,
+    "usage": {
+      "prompt": 561,
+      "completion": 219,
+      "reasoning": 0,
+      "total": 780
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1089",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が「spreading depression（拡大性抑制）」という神経生理学的現象を指しており、うつ病（depression）を対象とした研究ではない。動物を用いた研究ではあるが、うつ病モデルではない。"
+    ],
+    "durationMs": 4938,
+    "usage": {
+      "prompt": 764,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 898
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1090",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、体重減少（身体的抑制）を指している",
+      "対象が動物（barn swallow nestlings）ではあるが、うつ病モデルではない",
+      "免疫チャレンジによる生理的ストレスの影響を調べた研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5503,
+    "usage": {
+      "prompt": 760,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 913
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1091",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく犬であるが、うつ病（depression）の研究ではなく、循環器系への薬物影響を調べた研究であり、「depression」が呼吸抑制や心機能抑制などを指す可能性があるため、うつ病の動物モデル研究ではない"
+    ],
+    "durationMs": 7280,
+    "usage": {
+      "prompt": 885,
+      "completion": 214,
+      "reasoning": 0,
+      "total": 1099
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1092",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（Wistar rats）であり、うつ病の動物モデルに関する研究であるため"
+    ],
+    "durationMs": 7136,
+    "usage": {
+      "prompt": 838,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 1029
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1093",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される。また、「hypotensive activities」は血圧低下を指し、うつ病とは無関係である。"
+    ],
+    "durationMs": 4513,
+    "usage": {
+      "prompt": 410,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 530
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1094",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "動物モデルを用いたうつ病研究であり、ヒト研究ではないため"
+    ],
+    "durationMs": 5772,
+    "usage": {
+      "prompt": 726,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 887
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1095",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「depressive effects」として使用されているが、これは成長抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない。対象はニジマスで、うつ病の神経行動学的モデルではない。"
+    ],
+    "durationMs": 5319,
+    "usage": {
+      "prompt": 1020,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 1167
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1096",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は筋収縮の抑制（soleus muscleの収縮抑制）を指しており、うつ病モデルではない",
+      "対象は呼吸器および骨格筋の薬理作用であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4865,
+    "usage": {
+      "prompt": 544,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 681
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1097",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病の動物モデルに関する記述が見られず、対象が薬物代謝に関するものと推測されるため"
+    ],
+    "durationMs": 2696,
+    "usage": {
+      "prompt": 404,
+      "completion": 61,
+      "reasoning": 0,
+      "total": 465
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1098",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin silico（コンピュータシミュレーション）研究であり、in vivo動物モデルを用いていない"
+    ],
+    "durationMs": 6231,
+    "usage": {
+      "prompt": 738,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 906
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1099",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がうつ病ではなく、脳卒中後の痙縮（spasticity）に関する研究である"
+    ],
+    "durationMs": 5212,
+    "usage": {
+      "prompt": 863,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 1012
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1100",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2520,
+    "usage": {
+      "prompt": 421,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 474
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1101",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、動物実験であるため包含基準を満たす"
+    ],
+    "durationMs": 5497,
+    "usage": {
+      "prompt": 704,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 855
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1102",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病（depression）」に関連する記述がなく、腫瘍や免疫刺激に関する動物実験であるため、対象外である"
+    ],
+    "durationMs": 2998,
+    "usage": {
+      "prompt": 419,
+      "completion": 64,
+      "reasoning": 0,
+      "total": 483
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1103",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がPC12細胞（in vitroモデル）であり、in vivo動物モデルではないため"
+    ],
+    "durationMs": 4611,
+    "usage": {
+      "prompt": 720,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 842
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1104",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデル（学習性無力感パラダイム）に関する研究であり、in vivoモデルに該当する"
+    ],
+    "durationMs": 6069,
+    "usage": {
+      "prompt": 733,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 907
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1105",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋収縮抑制（contractile depression）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 3995,
+    "usage": {
+      "prompt": 822,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 922
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1106",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制（growth depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3789,
+    "usage": {
+      "prompt": 625,
+      "completion": 92,
+      "reasoning": 0,
+      "total": 717
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1107",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、心臓の伝導系に関する研究である。「depression」は心臓の抑制（cardiac depression）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5449,
+    "usage": {
+      "prompt": 756,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 911
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1108",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であるという証拠がない",
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性も含めて、対象とするうつ病モデル研究とは関連が認められない"
+    ],
+    "durationMs": 5070,
+    "usage": {
+      "prompt": 395,
+      "completion": 89,
+      "reasoning": 0,
+      "total": 484
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1109",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4896,
+    "usage": {
+      "prompt": 411,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 504
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1110",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓のCa2+電流の抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4437,
+    "usage": {
+      "prompt": 870,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 983
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1111",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（トランスジェニックマウス）を用いた研究であり、対象が動物実験であるため"
+    ],
+    "durationMs": 5860,
+    "usage": {
+      "prompt": 714,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 880
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1112",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経活動の抑制（synaptic depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4432,
+    "usage": {
+      "prompt": 790,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 897
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1113",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の語が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "副腎髄質からのカテコールアミン分泌に関する研究であり、うつ病とは無関係と判断される"
+    ],
+    "durationMs": 3563,
+    "usage": {
+      "prompt": 405,
+      "completion": 89,
+      "reasoning": 0,
+      "total": 494
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1114",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく心臓の抑制（cardiac depression）を指しており、対象外である"
+    ],
+    "durationMs": 4479,
+    "usage": {
+      "prompt": 795,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1115",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4094,
+    "usage": {
+      "prompt": 604,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 702
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1116",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした分子イメージング（PET）研究であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 5320,
+    "usage": {
+      "prompt": 816,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 968
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1117",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経活動の抑制（respiratory depressionなどと同様の生理的抑制）を指しており、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 4576,
+    "usage": {
+      "prompt": 410,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 538
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1118",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がマウス（in vivo動物モデル）であり、うつ病（depression）を関連疾患として扱っている動物実験であるため"
+    ],
+    "durationMs": 5946,
+    "usage": {
+      "prompt": 688,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 849
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1119",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、肝臓スライスおよび肝腫瘍細胞におけるアミノ酸取り込みの生化学的影響を調べた研究である"
+    ],
+    "durationMs": 2887,
+    "usage": {
+      "prompt": 495,
+      "completion": 70,
+      "reasoning": 0,
+      "total": 565
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1120",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が精神疾患としてのうつ病ではなく、全身状態の抑うつ（vital depression）を指している",
+      "対象は犬の壊死性筋膜炎症例であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4951,
+    "usage": {
+      "prompt": 628,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 765
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1121",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "強制泳動試験（forced swim test）を用いてうつ病関連行動を評価しており、in vivo動物モデルを用いたうつ病研究である"
+    ],
+    "durationMs": 4475,
+    "usage": {
+      "prompt": 722,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 836
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1122",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoのラットを用いたストレスと神経可塑性に関する研究であり、うつ病の動物モデルとして関連する可能性があるため"
+    ],
+    "durationMs": 5361,
+    "usage": {
+      "prompt": 674,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 819
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1123",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、抄録が欠如しているため、うつ病の動物モデルに関する研究かどうか判断できない"
+    ],
+    "durationMs": 2758,
+    "usage": {
+      "prompt": 401,
+      "completion": 61,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1124",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象が環節動物（多毛類）の胚発生であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4355,
+    "usage": {
+      "prompt": 555,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 674
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1125",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が海洋二枚貝（ムール貝）のハイブリッドゾーンに関する遺伝学的研究であり、うつ病のin vivo動物モデルを扱っていない。文中の'depression'は'hybrid depression'（ハイブリッド劣勢）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5611,
+    "usage": {
+      "prompt": 812,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 962
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1126",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または神経生理学的抑制（例：シナプス伝達の抑制）を指しており、うつ病モデルではない",
+      "in vivo ではなく in vitro（ラット海馬スライス）を用いた実験",
+      "うつ病に関する動物モデルの研究ではない"
+    ],
+    "durationMs": 6628,
+    "usage": {
+      "prompt": 865,
+      "completion": 193,
+      "reasoning": 0,
+      "total": 1058
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1127",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 2271,
+    "usage": {
+      "prompt": 409,
+      "completion": 50,
+      "reasoning": 0,
+      "total": 459
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1128",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓の収縮機能低下（心機能抑制）を指しており、うつ病モデルではない",
+      "対象がうつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 4421,
+    "usage": {
+      "prompt": 497,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 615
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1129",
+    "label_included": 0,
+    "include_probability": 0.6,
+    "reasons": [
+      "タイトルに「rat（ラット）」が含まれており、in vivo動物モデルの可能性があるが、うつ病モデルかどうかは抄録がなく不明である。感度を優先し、フルテキスト確認が必要と判断される。"
+    ],
+    "durationMs": 4306,
+    "usage": {
+      "prompt": 410,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 530
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1130",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではないと判断される",
+      "タイトルに「depression」の語が含まれておらず、呼吸抑制や心機能抑制などの文脈も確認できないが、対象が神経伝達物質やカルシウムの隔離に焦点を当てた生化学的メカニズムの研究と推測される"
+    ],
+    "durationMs": 3969,
+    "usage": {
+      "prompt": 407,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 513
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1131",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、シナプスの長期抑圧（long-term depression, LTD）を指しているため、対象外である"
+    ],
+    "durationMs": 6007,
+    "usage": {
+      "prompt": 569,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 727
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1132",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がアルツハイマー病であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 3712,
+    "usage": {
+      "prompt": 799,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 894
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1133",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "抄録にラットを用いたうつ病の動物モデル（FSLラット、慢性軽度ストレス、早期母子分離など）に関する記述があり、in vivo動物実験が含まれている"
+    ],
+    "durationMs": 5653,
+    "usage": {
+      "prompt": 767,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 929
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1134",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ジアゼパムによる学習・記憶障害を調べた研究である"
+    ],
+    "durationMs": 4058,
+    "usage": {
+      "prompt": 405,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 511
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1135",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2197,
+    "usage": {
+      "prompt": 424,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 475
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1136",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ラットの足浮腫（炎症）モデルを用いた研究である"
+    ],
+    "durationMs": 4120,
+    "usage": {
+      "prompt": 416,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 516
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1137",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ジエチルスチルベステロールが雄ラットの皮膚ステロールに与える影響を調べた研究である"
+    ],
+    "durationMs": 6670,
+    "usage": {
+      "prompt": 706,
+      "completion": 194,
+      "reasoning": 0,
+      "total": 900
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1138",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 2650,
+    "usage": {
+      "prompt": 406,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 463
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1139",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物モデルを用いたうつ病研究ではなく、抗がん抗体の結晶構造に関する生化学的研究である"
+    ],
+    "durationMs": 6360,
+    "usage": {
+      "prompt": 909,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 1085
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1140",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット肝細胞であり、うつ病のin vivoモデルではない",
+      "「depression」はグルタチオン（GSH）の低下を指しており、精神疾患としてのうつ病ではない"
+    ],
+    "durationMs": 4491,
+    "usage": {
+      "prompt": 752,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 871
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1141",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトおよび非ヒト霊長類を対象とした神経解剖学的研究であり、うつ病のin vivo動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 7801,
+    "usage": {
+      "prompt": 753,
+      "completion": 229,
+      "reasoning": 0,
+      "total": 982
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1142",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "霊長類（baboons）を用いたうつ病モデルに関するin vivo研究であり、ヒト研究ではない"
+    ],
+    "durationMs": 4974,
+    "usage": {
+      "prompt": 488,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 625
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1143",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、スタイレン処理によるラットの酵素活性低下に関する研究である"
+    ],
+    "durationMs": 6087,
+    "usage": {
+      "prompt": 689,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 864
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1144",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、ヒト研究ではない。また、「depression」は行動の抑制（回避行動の低下）を指しており、呼吸抑制や心機能抑制などの他の意味ではない。"
+    ],
+    "durationMs": 6960,
+    "usage": {
+      "prompt": 604,
+      "completion": 199,
+      "reasoning": 0,
+      "total": 803
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1145",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病（depression）に関する記述がなく、血圧作用に関する研究であることが示唆されている",
+      "動物モデルを用いたうつ病研究であることを示すエビデンスが全くない"
+    ],
+    "durationMs": 3228,
+    "usage": {
+      "prompt": 417,
+      "completion": 77,
+      "reasoning": 0,
+      "total": 494
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1146",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）の動物モデルに関する研究ではなく、神経生理学的現象（活動後過分極の抑制）に関する研究である。「depression」は心臓や呼吸の抑制を意味するものではなく、活動電位後の過分極の抑制を指しているが、これはうつ病とは無関係である。"
+    ],
+    "durationMs": 6010,
+    "usage": {
+      "prompt": 687,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 846
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1147",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、脾臓における赤血球産生（erythropoiesis）の抑制を調べた動物実験である。「depression」が呼吸抑制や心機能抑制などを意味する用法ではなくとも、本研究では「depression」がそもそも使用されておらず、うつ病モデルではない。"
+    ],
+    "durationMs": 4076,
+    "usage": {
+      "prompt": 645,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 751
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1148",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究はin vivoうつ病モデルではなく、in vitroでウサギ肺を用いた生体外実験であり、うつ病の動物モデルではない。また、「depression」は5-HT取り込みの抑制（機能的抑制）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 6880,
+    "usage": {
+      "prompt": 751,
+      "completion": 202,
+      "reasoning": 0,
+      "total": 953
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1149",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動の動物モデル研究であり、対象がin vivoであるため"
+    ],
+    "durationMs": 5559,
+    "usage": {
+      "prompt": 883,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 1037
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1150",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は麻酔薬による神経機能の抑制（例：righting-responseの喪失）を指しており、うつ病モデルではない",
+      "研究は麻酔作用の機序を調べるもので、うつ病の動物モデルを用いていない"
+    ],
+    "durationMs": 5337,
+    "usage": {
+      "prompt": 793,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 932
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1151",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がミニピッグであるが、研究目的が抗うつ治療のメカニズム解明であり、うつ病のin vivoモデルを用いた研究ではない"
+    ],
+    "durationMs": 7196,
+    "usage": {
+      "prompt": 779,
+      "completion": 193,
+      "reasoning": 0,
+      "total": 972
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1152",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」の記載がなく、代謝効果に関する哺乳動物細胞の研究であり、in vivo うつ病モデルの動物研究ではないと判断される"
+    ],
+    "durationMs": 3020,
+    "usage": {
+      "prompt": 399,
+      "completion": 75,
+      "reasoning": 0,
+      "total": 474
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1153",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivo動物モデルを用いたうつ病研究ではなく、受容体の変異および計算モデルを用いたin vitro研究である"
+    ],
+    "durationMs": 4233,
+    "usage": {
+      "prompt": 917,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 1027
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1154",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「spreading depression（拡大性抑制）」を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5176,
+    "usage": {
+      "prompt": 869,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 1008
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1155",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2628,
+    "usage": {
+      "prompt": 406,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 457
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1156",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓抑制（cardiovascular depression）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 5299,
+    "usage": {
+      "prompt": 815,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 964
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1157",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や動物モデルに関する言及がなく、抄録が存在しないため、対象外と判断できる"
+    ],
+    "durationMs": 2875,
+    "usage": {
+      "prompt": 397,
+      "completion": 61,
+      "reasoning": 0,
+      "total": 458
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1158",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）に関する言及がなく、腎臓のプロスタグランジンや脂質滴に関する研究であるため、対象外と判断される"
+    ],
+    "durationMs": 3038,
+    "usage": {
+      "prompt": 408,
+      "completion": 75,
+      "reasoning": 0,
+      "total": 483
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1159",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がサル（ヒト以外の霊長類）であるが、本研究はヒトを含む臨床前イメージング研究であり、うつ病のin vivo動物モデルを使用していない。うつ病との関連は背景情報として言及されているのみで、動物うつ病モデルを用いた実験ではない。"
+    ],
+    "durationMs": 7426,
+    "usage": {
+      "prompt": 765,
+      "completion": 210,
+      "reasoning": 0,
+      "total": 975
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1160",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はうつ病ではなく、脳内の「拡がる抑制（spreading depression）」を指しており、呼吸抑制や循環抑制と同様に神経生理学的現象である"
+    ],
+    "durationMs": 6297,
+    "usage": {
+      "prompt": 725,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 904
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1161",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、長期抑圧（long-term depression: LTD）という神経可塑性を指している",
+      "対象がうつ病モデル動物ではなく、認知機能障害モデル（スコポラミン投与ラット）およびヒトである",
+      "ヒトデータが含まれており、動物実験のみという基準に合致しない"
+    ],
+    "durationMs": 8740,
+    "usage": {
+      "prompt": 653,
+      "completion": 256,
+      "reasoning": 0,
+      "total": 909
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1162",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が猫の心室筋であり、うつ病のin vivoモデルに関する研究ではない。また、「depression」が心臓の陰性変力作用（cardiac depression）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5322,
+    "usage": {
+      "prompt": 473,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 615
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1163",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であるという根拠がない"
+    ],
+    "durationMs": 2551,
+    "usage": {
+      "prompt": 407,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 458
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1164",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルではなく、卵巣におけるインターロイキンの影響を調べた研究である"
+    ],
+    "durationMs": 6916,
+    "usage": {
+      "prompt": 961,
+      "completion": 204,
+      "reasoning": 0,
+      "total": 1165
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1165",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、胃酸分泌抑制および抗潰瘍作用に関する動物実験である"
+    ],
+    "durationMs": 6126,
+    "usage": {
+      "prompt": 713,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 887
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1166",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の低下（心臓の抑制）を指しており、うつ病モデルではない",
+      "対象が新生子ラムであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5381,
+    "usage": {
+      "prompt": 550,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 672
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1167",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する動物実験であり、ヒト研究ではない。うつ病は呼吸抑制や心機能抑制ではなく、行動学的テスト（強制泳泳試験、尾懸垂試験）で評価されている。"
+    ],
+    "durationMs": 7386,
+    "usage": {
+      "prompt": 719,
+      "completion": 222,
+      "reasoning": 0,
+      "total": 941
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1168",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が腸管粘膜免疫機能の抑制（depression of intestinal mucosal immune function）を指しており、うつ病（depression）ではない",
+      "対象は外傷・出血ショック後の免疫機能に関する動物実験であり、うつ病モデルではない"
+    ],
+    "durationMs": 5139,
+    "usage": {
+      "prompt": 758,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 900
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1169",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、脳の「拡大性抑制（spreading depression）」を指しており、これは神経生理学的な現象であるため、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5725,
+    "usage": {
+      "prompt": 623,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 789
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1170",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3910,
+    "usage": {
+      "prompt": 836,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 942
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1171",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）に関する記述がなく、腎臓由来の(Na+ + K+)-ATPaseの生化学的研究であるため、うつ病のin vivo動物モデルの研究ではないと判断される"
+    ],
+    "durationMs": 3509,
+    "usage": {
+      "prompt": 437,
+      "completion": 86,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1172",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルを対象とした研究ではなく、大脳皮質刺激に対するラット淡蒼球細胞の反応とドパミン作動性活動の影響に関する神経生理学的研究である。うつ病に関する記述は一切含まれていない。"
+    ],
+    "durationMs": 3716,
+    "usage": {
+      "prompt": 734,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 827
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1173",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が腎臓障害であり、うつ病（depression）の動物モデルに関する研究ではない。文中の'depression'はMDAレベルの低下を意味しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 4664,
+    "usage": {
+      "prompt": 761,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 891
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1174",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット海馬スライス（in vitro）であり、in vivoうつ病モデルではない"
+    ],
+    "durationMs": 3866,
+    "usage": {
+      "prompt": 699,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 797
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1175",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が長期抑圧（long-term depression）として神経生理学的現象を指しており、うつ病モデルではない",
+      "研究はメスアンフェタミン誘発性過活動の抑制を調べており、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4946,
+    "usage": {
+      "prompt": 708,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 843
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1176",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋収縮力の抑制（心臓の抑制）を指しており、うつ病モデルではない",
+      "対象はイヌの心筋組織であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 4691,
+    "usage": {
+      "prompt": 727,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 856
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1177",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトでのイメージングを目的とした動物実験であり、うつ病のin vivoモデルとしての評価や誘発が行われていない"
+    ],
+    "durationMs": 6155,
+    "usage": {
+      "prompt": 1100,
+      "completion": 181,
+      "reasoning": 0,
+      "total": 1281
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1178",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、聴覚神経回路におけるシナプス抑制のメカニズムに関する研究である。うつ病（depression）という語はシナプス疲労（synaptic depression）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5838,
+    "usage": {
+      "prompt": 838,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 1006
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1179",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラット（in vivo動物モデル）を用いてうつ病関連の神経内分泌メカニズムを検討しており、うつ病の動物モデル研究に該当する"
+    ],
+    "durationMs": 5953,
+    "usage": {
+      "prompt": 886,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 1053
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1180",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病モデルの動物実験であり、うつ病（精神疾患）に関する研究である"
+    ],
+    "durationMs": 6774,
+    "usage": {
+      "prompt": 761,
+      "completion": 201,
+      "reasoning": 0,
+      "total": 962
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1181",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "副腎からのステロイド分泌を調べた研究であり、うつ病とは無関係"
+    ],
+    "durationMs": 4078,
+    "usage": {
+      "prompt": 404,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 514
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1182",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3811,
+    "usage": {
+      "prompt": 721,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 819
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1183",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから人間の臨床研究であることが示唆されており、動物モデルに関する記述がない"
+    ],
+    "durationMs": 3493,
+    "usage": {
+      "prompt": 407,
+      "completion": 89,
+      "reasoning": 0,
+      "total": 496
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1184",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が犬であり、うつ病のin vivoモデルに関する研究ではない。また、「depression」が呼吸抑制や循環抑制などを指す可能性があり、精神疾患としてのうつ病とは無関係と判断される。"
+    ],
+    "durationMs": 4622,
+    "usage": {
+      "prompt": 420,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 541
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1185",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病ラットモデルを用いたin vivo動物実験であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 5090,
+    "usage": {
+      "prompt": 735,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 874
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1186",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）の動物モデルに関する研究ではなく、小脳における長期抑圧（long-term depression）という神経生理学的現象を扱っている"
+    ],
+    "durationMs": 4682,
+    "usage": {
+      "prompt": 675,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 799
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1187",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトル中の「depression」は血液凝固系の機能低下を指しており、うつ病の動物モデルではない可能性が高い",
+      "抄録がなく、研究対象が動物か人間か判断できないが、文脈から生理的機能の抑制を指していると推測される"
+    ],
+    "durationMs": 5537,
+    "usage": {
+      "prompt": 415,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 561
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1188",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫機能の低下（Tリンパ球増殖の抑制）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4778,
+    "usage": {
+      "prompt": 768,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 880
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1189",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」とあるが、動物モデルに関する記述がなく、ヒト研究か動物研究か判断できないため"
+    ],
+    "durationMs": 3608,
+    "usage": {
+      "prompt": 399,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 490
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1190",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "強制泳動試験（FST）を用いてうつ様行動を評価しており、in vivo動物モデルを用いたうつ病関連研究である"
+    ],
+    "durationMs": 5058,
+    "usage": {
+      "prompt": 896,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 1026
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1191",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が生体外（臓器培養スライス）であり、in vivoモデルではない",
+      "うつ病（depression）に関する研究ではなく、酸素欠乏および再酸素化による神経機能障害を調べている"
+    ],
+    "durationMs": 7282,
+    "usage": {
+      "prompt": 793,
+      "completion": 206,
+      "reasoning": 0,
+      "total": 999
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1192",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いたin vivo研究であり、ヒト研究ではないため"
+    ],
+    "durationMs": 4130,
+    "usage": {
+      "prompt": 751,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 848
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1193",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、心筋機能抑制に関する研究であり、うつ病の動物モデルに関するものではない"
+    ],
+    "durationMs": 3754,
+    "usage": {
+      "prompt": 407,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 507
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1194",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（マウス）を用いた研究であり、行動テスト（sucrose preference test、forced-swim test）でうつ様行動を評価している。対象はヒトではなく、呼吸抑制や心機能抑制などの「depression」ではない。"
+    ],
+    "durationMs": 7865,
+    "usage": {
+      "prompt": 900,
+      "completion": 222,
+      "reasoning": 0,
+      "total": 1122
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1195",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3696,
+    "usage": {
+      "prompt": 593,
+      "completion": 89,
+      "reasoning": 0,
+      "total": 682
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1196",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、カエル交感神経節におけるシナプス伝達の長期増強現象を調べた研究である。「depression」は本研究において一時的な神経伝達抑制（post-tetanic depression）を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 7656,
+    "usage": {
+      "prompt": 896,
+      "completion": 223,
+      "reasoning": 0,
+      "total": 1119
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1197",
+    "label_included": 0,
+    "include_probability": 0.3,
+    "reasons": [
+      "うつ病の動物モデルを直接使用している記述はなく、心筋梗塞後のうつ症状について言及しているが、うつ病モデルとして研究しているわけではない"
+    ],
+    "durationMs": 5046,
+    "usage": {
+      "prompt": 623,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 740
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1198",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression（うつ病）」に関連する記述がなく、メラノフォアの分散に関する研究であり、うつ病のin vivoモデルを対象としていないと判断される"
+    ],
+    "durationMs": 4617,
+    "usage": {
+      "prompt": 405,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 530
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1199",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅覚球摘出ラットを用いたうつ病モデルに関する動物実験であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない。"
+    ],
+    "durationMs": 5767,
+    "usage": {
+      "prompt": 719,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 884
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1200",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではないと判断される",
+      "タイトルに「depression」の語が含まれておらず、対象が動物か人間か不明だが、noradrenalineおよびalpha-methyldopaの文脈からヒトを対象とした臨床研究の可能性が高い"
+    ],
+    "durationMs": 3535,
+    "usage": {
+      "prompt": 413,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 506
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1201",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、グルコース代謝に関する研究である"
+    ],
+    "durationMs": 3363,
+    "usage": {
+      "prompt": 409,
+      "completion": 86,
+      "reasoning": 0,
+      "total": 495
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1202",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラットの血管組織を用いたin vitro実験であり、in vivoうつ病モデルではない",
+      "「depression」が心臓や呼吸の抑制を意味するものではなく、本研究ではそもそもうつ病に関連していない"
+    ],
+    "durationMs": 4928,
+    "usage": {
+      "prompt": 726,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 857
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1203",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋収縮の抑制（心臓の抑制）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5430,
+    "usage": {
+      "prompt": 975,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 1128
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1204",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患が強迫性障害（OCD）であり、うつ病のin vivoモデルに関する研究ではない",
+      "抄録内で「depression-like behavior」という記載はあるが、主要な研究目的や評価項目ではないため、うつ病モデル研究とは判断できない"
+    ],
+    "durationMs": 6057,
+    "usage": {
+      "prompt": 894,
+      "completion": 173,
+      "reasoning": 0,
+      "total": 1067
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1205",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓収縮力の抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4287,
+    "usage": {
+      "prompt": 616,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 728
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1206",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、骨格筋の活動電位に関する研究である"
+    ],
+    "durationMs": 6263,
+    "usage": {
+      "prompt": 596,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 763
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1207",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "強制泳ぎ試験（Porsolt forced-swim test）を用いたうつ病の動物モデルに関する研究であり、in vivo のマウスを対象としているため"
+    ],
+    "durationMs": 5224,
+    "usage": {
+      "prompt": 743,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 882
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1208",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や代謝抑制などうつ病以外の意味で使用されており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4332,
+    "usage": {
+      "prompt": 777,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 891
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1209",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5639,
+    "usage": {
+      "prompt": 693,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 848
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1210",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ジギタリン誘発性不整脈および心筋へのジギタリン取り込みに関する研究である",
+      "「depression」がうつ病を指している証拠がなく、むしろ心機能の抑制（cardiac depression）に関連する可能性がある"
+    ],
+    "durationMs": 6064,
+    "usage": {
+      "prompt": 423,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 578
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1211",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "抄録に動物モデルやうつ病のin vivo評価に関する記述がなく、in vitroまたは化学合成研究の可能性が高い"
+    ],
+    "durationMs": 3004,
+    "usage": {
+      "prompt": 587,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 646
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1212",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様行動の動物実験であり、in vivoモデルのうつ病研究である"
+    ],
+    "durationMs": 5749,
+    "usage": {
+      "prompt": 563,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 728
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1213",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルに関する研究ではなく、ドパミン動態の基礎神経科学的研究である",
+      "抄録中に「depression」は「presynaptic depression」として登場するが、これはうつ病ではなくシナプス機能の抑制を指す"
+    ],
+    "durationMs": 5322,
+    "usage": {
+      "prompt": 755,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 902
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1214",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、心筋収縮抑制（myocardial contractile depression）を指しており、対象外である"
+    ],
+    "durationMs": 4079,
+    "usage": {
+      "prompt": 777,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 884
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1215",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が筋収縮の抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5112,
+    "usage": {
+      "prompt": 643,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 786
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1216",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3708,
+    "usage": {
+      "prompt": 853,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 944
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1217",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す情報がない"
+    ],
+    "durationMs": 2693,
+    "usage": {
+      "prompt": 400,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 455
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1218",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoマウスを用いたうつ病モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などを指す「depression」ではない"
+    ],
+    "durationMs": 5361,
+    "usage": {
+      "prompt": 591,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 740
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1219",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病の動物モデルに関する研究かどうか不明である。抄録が存在しないため、対象疾患やモデルの詳細が確認できない。"
+    ],
+    "durationMs": 3116,
+    "usage": {
+      "prompt": 405,
+      "completion": 71,
+      "reasoning": 0,
+      "total": 476
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1220",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸・循環機能の抑制（cardiovascular depression）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4126,
+    "usage": {
+      "prompt": 619,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 725
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1221",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が行動抑制（locomotor depression）を指しており、うつ病モデルではない",
+      "対象がマウスであるが、うつ病のin vivoモデルではなく薬理学的行動観察である",
+      "呼吸抑制や心機能低下ではないが、精神疾患としての「うつ病」を対象としていない"
+    ],
+    "durationMs": 7213,
+    "usage": {
+      "prompt": 1178,
+      "completion": 215,
+      "reasoning": 0,
+      "total": 1393
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1222",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫機能の抑制（delayed-type skin reactions の depression）を指しており、うつ病モデルではない",
+      "対象は動物（ウサギ）だが、うつ病の in vivo モデルに関する研究ではない"
+    ],
+    "durationMs": 4918,
+    "usage": {
+      "prompt": 610,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 744
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1223",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性ストレスラットを用いたうつ病モデルに関する動物実験であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」でもない"
+    ],
+    "durationMs": 5700,
+    "usage": {
+      "prompt": 688,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 839
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1224",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、正常な雄ラットにおけるエストラジオール安息香酸エステルの下垂体および精巣機能への影響を調べた研究であるため"
+    ],
+    "durationMs": 4759,
+    "usage": {
+      "prompt": 411,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 541
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1225",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」や動物モデルに関する記述がなく、対象が血管の自己調節や神経栄養性血管拡張薬であるため、うつ病のin vivo動物研究とは関連しないと判断される"
+    ],
+    "durationMs": 5206,
+    "usage": {
+      "prompt": 408,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 549
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1226",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が運動抑制（motor depressant effects）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3787,
+    "usage": {
+      "prompt": 552,
+      "completion": 94,
+      "reasoning": 0,
+      "total": 646
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1227",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "抄録にラットおよびマウスを用いたうつ病の動物モデルに関する記述がある"
+    ],
+    "durationMs": 8612,
+    "usage": {
+      "prompt": 621,
+      "completion": 257,
+      "reasoning": 0,
+      "total": 878
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1228",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がマウスを用いたうつ病関連のin vivo研究であり、ヒト研究や呼吸・心機能の抑制とは無関係である"
+    ],
+    "durationMs": 8527,
+    "usage": {
+      "prompt": 574,
+      "completion": 254,
+      "reasoning": 0,
+      "total": 828
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1229",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病様行動を評価するin vivo動物モデル（マウス）を用いた研究であり、対象がヒトでなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 4802,
+    "usage": {
+      "prompt": 746,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 879
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1230",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、動物実験であるため"
+    ],
+    "durationMs": 4692,
+    "usage": {
+      "prompt": 728,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 849
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1231",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的な抑制現象（樹状突起電位の抑制）を指しており、うつ病モデルではない",
+      "対象がネコであるが、うつ病のin vivoモデルではなく、麻酔下での神経生理学的実験である"
+    ],
+    "durationMs": 7199,
+    "usage": {
+      "prompt": 612,
+      "completion": 210,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1232",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "慢性軽度ストレス（CMS）モデルを用いたラットを対象としたうつ病の動物実験であり、in vivoモデルに該当する"
+    ],
+    "durationMs": 4885,
+    "usage": {
+      "prompt": 760,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 899
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1233",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、犬の近親交配が産子数と生存に与える影響を調査した研究である"
+    ],
+    "durationMs": 4373,
+    "usage": {
+      "prompt": 556,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 663
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1234",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）や動物モデルに関する記述が全く含まれていない"
+    ],
+    "durationMs": 2239,
+    "usage": {
+      "prompt": 415,
+      "completion": 52,
+      "reasoning": 0,
+      "total": 467
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1235",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制など非精神疾患の文脈で使用されており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4366,
+    "usage": {
+      "prompt": 731,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 844
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1236",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が生殖器重量の低下を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3866,
+    "usage": {
+      "prompt": 855,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 957
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1237",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する動物研究ではなく、染色体と性比に関する研究である"
+    ],
+    "durationMs": 2549,
+    "usage": {
+      "prompt": 677,
+      "completion": 50,
+      "reasoning": 0,
+      "total": 727
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1238",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や心臓抑制など精神疾患としてのうつ病とは無関係な文脈で使用されている",
+      "対象がイヌの心室筋であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 7579,
+    "usage": {
+      "prompt": 844,
+      "completion": 184,
+      "reasoning": 0,
+      "total": 1028
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1239",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」が含まれておらず、外傷性ショックに関する研究であり、うつ病の動物モデルに関するものではない"
+    ],
+    "durationMs": 2742,
+    "usage": {
+      "prompt": 401,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 466
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1240",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経科学における長期抑性（long-term depression, LTD）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5323,
+    "usage": {
+      "prompt": 802,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 951
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1241",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能低下などの生理的抑制を指しており、うつ病（depression as a mental disorder）に関する研究ではない",
+      "対象がラットであるが、うつ病モデルではなく免疫機能の日内リズムに関する研究"
+    ],
+    "durationMs": 5209,
+    "usage": {
+      "prompt": 789,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 937
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1242",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）に関する記述がなく、研究対象がクロストリジウム・ペルフランジェンスのα毒素の溶血活性であるため、うつ病のin vivoモデル研究ではない"
+    ],
+    "durationMs": 4433,
+    "usage": {
+      "prompt": 432,
+      "completion": 86,
+      "reasoning": 0,
+      "total": 518
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1243",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であるという根拠がない"
+    ],
+    "durationMs": 2413,
+    "usage": {
+      "prompt": 421,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 472
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1244",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「respiratory depression」や「cardiac depression」ではなく、うつ病を指している可能性があるか検討したが、抄録中の「depressed the uptake」は肝臓への取り込みが低下したことを意味しており、うつ病とは無関係である。また、研究は腫瘍マウスを用いたリポソーム分布の検討であり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 6425,
+    "usage": {
+      "prompt": 665,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 847
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1245",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が生理機能の抑制（PAH輸送の低下）を指しており、うつ病モデルではない",
+      "対象が蛇の腎臓であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 5096,
+    "usage": {
+      "prompt": 697,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 818
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1246",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」が含まれておらず、成長ホルモン分泌に関する研究であり、うつ病の動物モデルの研究ではないと判断される"
+    ],
+    "durationMs": 3132,
+    "usage": {
+      "prompt": 404,
+      "completion": 68,
+      "reasoning": 0,
+      "total": 472
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1247",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト以外の霊長類（baboon）を対象とした研究だが、うつ病モデルに関する記述がなく、急性毒性試験でありうつ病のin vivoモデルとは関係ない"
+    ],
+    "durationMs": 4419,
+    "usage": {
+      "prompt": 425,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 540
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1248",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、リチウム塩がラットの甲状腺におけるヨウ素取り込みに与える影響を調べた研究である"
+    ],
+    "durationMs": 4321,
+    "usage": {
+      "prompt": 404,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 517
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1249",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」に関する記載がなく、抄録が存在しないため、うつ病のin vivoモデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2778,
+    "usage": {
+      "prompt": 400,
+      "completion": 67,
+      "reasoning": 0,
+      "total": 467
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1250",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「animal experimental aspects」とあるが、抄録全体はヒトのうつ病治療抵抗性に焦点を当てており、動物実験の内容が明確でない。感度を重視し、判断保留の場合は含めるべきだが、動物モデルの使用が明言されていないため確実性に欠ける。"
+    ],
+    "durationMs": 5142,
+    "usage": {
+      "prompt": 509,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 653
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1251",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病の動物モデルに関する研究であるという証拠がない"
+    ],
+    "durationMs": 2293,
+    "usage": {
+      "prompt": 422,
+      "completion": 52,
+      "reasoning": 0,
+      "total": 474
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1252",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関するin vivo動物実験であり、対象とするうつ病が精神疾患としてのうつ病であることが明確である。"
+    ],
+    "durationMs": 7069,
+    "usage": {
+      "prompt": 874,
+      "completion": 209,
+      "reasoning": 0,
+      "total": 1083
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1253",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」または「depression」に関する記述がなく、抄録が存在しないため、動物モデルを用いたうつ病研究であると判断できない"
+    ],
+    "durationMs": 3003,
+    "usage": {
+      "prompt": 410,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 475
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1254",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がマウスを用いたうつ病行動のin vivo研究であり、ヒト研究や呼吸抑制などを指す「depression」ではない"
+    ],
+    "durationMs": 6813,
+    "usage": {
+      "prompt": 824,
+      "completion": 203,
+      "reasoning": 0,
+      "total": 1027
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1255",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がin vivoうつ病モデルではなく、in vitroのブタ甲状腺細胞を用いた実験である。うつ病に関する記述は一切含まれていない。"
+    ],
+    "durationMs": 4975,
+    "usage": {
+      "prompt": 787,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 902
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1256",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病（depression）」に関する記載がなく、トリコチロマニア（抜毛症）に関する皮膚科学の論文と推測されるため、対象外"
+    ],
+    "durationMs": 2950,
+    "usage": {
+      "prompt": 404,
+      "completion": 71,
+      "reasoning": 0,
+      "total": 475
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1257",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルではなく、カエルの神経筋接合部を用いた電気生理学的実験であり、「depression」は神経伝達の抑制（depression of evoked quantal release）を指している"
+    ],
+    "durationMs": 5572,
+    "usage": {
+      "prompt": 979,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 1133
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1258",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、血小板機能および膜モデルを用いた薬理学的研究である"
+    ],
+    "durationMs": 6230,
+    "usage": {
+      "prompt": 821,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 1000
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1259",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が生体内うつ病モデルではなく、内皮細胞を用いたin vitro実験である",
+      "うつ病（depression）に関する研究ではなく、一酸化窒素の内皮細胞機能への影響を調べたもの"
+    ],
+    "durationMs": 5215,
+    "usage": {
+      "prompt": 943,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 1087
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1260",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はシナプス抑制（synaptic depression）を指しており、うつ病モデルではない",
+      "in vitro（試験管内）実験であり、in vivoモデルではない",
+      "動物行動やうつ病様状態の評価は含まれていない"
+    ],
+    "durationMs": 6588,
+    "usage": {
+      "prompt": 571,
+      "completion": 180,
+      "reasoning": 0,
+      "total": 751
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1261",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来のサンプルを用いた研究であり、うつ病のin vivo動物モデルに関するものではない"
+    ],
+    "durationMs": 5305,
+    "usage": {
+      "prompt": 614,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 753
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1262",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究が含まれており、抄録にラットを用いた強制遊泳試験などのin vivo実験が明記されている"
+    ],
+    "durationMs": 5306,
+    "usage": {
+      "prompt": 775,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 914
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1263",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルがうつ病の動物モデルに関するものではなく、麻酔薬の腎機能への影響を扱っていると推測される"
+    ],
+    "durationMs": 4006,
+    "usage": {
+      "prompt": 399,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 507
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1264",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が精神疾患としてのうつ病ではなく、脊髄におけるシナプス活動の抑制（synaptic depression）を指している"
+    ],
+    "durationMs": 5457,
+    "usage": {
+      "prompt": 788,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 939
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1265",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が犬の心臓であり、うつ病のin vivoモデルではない。また、「depression」が心臓抑制（cardiac depression）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6478,
+    "usage": {
+      "prompt": 794,
+      "completion": 190,
+      "reasoning": 0,
+      "total": 984
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1266",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、心臓の副交感神経の発達を調べた研究である。「depression」が用いられておらず、うつ病とは無関係である。"
+    ],
+    "durationMs": 4239,
+    "usage": {
+      "prompt": 667,
+      "completion": 78,
+      "reasoning": 0,
+      "total": 745
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1267",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、動物実験であることが明確"
+    ],
+    "durationMs": 5124,
+    "usage": {
+      "prompt": 811,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 956
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1268",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなく、離体臓器（モルモット回腸縦走筋）を用いたin vitro実験である",
+      "うつ病（depression）に関する研究ではなく、オピオイドの耐性・依存性に関する研究である"
+    ],
+    "durationMs": 6926,
+    "usage": {
+      "prompt": 666,
+      "completion": 193,
+      "reasoning": 0,
+      "total": 859
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1269",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がうつ病ではなく多発性骨髄腫であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 5698,
+    "usage": {
+      "prompt": 610,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 771
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1270",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する記述がなく、研究対象がシナプス可塑性に限定されている"
+    ],
+    "durationMs": 2591,
+    "usage": {
+      "prompt": 483,
+      "completion": 56,
+      "reasoning": 0,
+      "total": 539
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1271",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、覚醒反応の抑制（arousal depression）を指しており、呼吸・覚醒関連の生理学的抑制を意味している"
+    ],
+    "durationMs": 5958,
+    "usage": {
+      "prompt": 771,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 945
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1272",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能低下などの文脈で使われており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4394,
+    "usage": {
+      "prompt": 761,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1273",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない",
+      "抄録にうつ病や関連する行動評価の記載がない"
+    ],
+    "durationMs": 2387,
+    "usage": {
+      "prompt": 510,
+      "completion": 56,
+      "reasoning": 0,
+      "total": 566
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1274",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」または「depression」に関する記述がなく、抄録が存在しないため、うつ病のin vivo動物モデルに関する研究かどうか判断できないが、タイトルから関連性が極めて低く、対象外と判断できる"
+    ],
+    "durationMs": 3425,
+    "usage": {
+      "prompt": 398,
+      "completion": 85,
+      "reasoning": 0,
+      "total": 483
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1275",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」や「うつ病」に関する記述がなく、疼痛および抗炎症作用に関する研究であると推測されるため、うつ病のin vivoモデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2963,
+    "usage": {
+      "prompt": 408,
+      "completion": 70,
+      "reasoning": 0,
+      "total": 478
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1276",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（マウス）を用いたin vivo研究であり、感情障害および不安障害のモデルとして強制水泳試験を含む行動評価を行っている。"
+    ],
+    "durationMs": 5777,
+    "usage": {
+      "prompt": 715,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 881
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1277",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、新生児ラット小脳由来の分散細胞培養を用いたGABA取り込みのin vitro研究である。動物全体を用いたin vivoモデルではないため、組み入れ基準を満たさない。"
+    ],
+    "durationMs": 5470,
+    "usage": {
+      "prompt": 857,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 998
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1278",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が神経伝達物質放出の「低下」を指しており、うつ病（depression）の動物モデルに関する研究ではない。呼吸性または心臓性の抑制でもなく、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5435,
+    "usage": {
+      "prompt": 1016,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 1172
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1279",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が体重増加の抑制（BW depression）を指しており、うつ病（depression）の動物モデルではない",
+      "対象は七面鳥であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4856,
+    "usage": {
+      "prompt": 763,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1280",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制（growth depression）を指しており、うつ病モデルではない",
+      "対象は酸化ストレスに対するアミノ酸補充の影響を調べた動物実験だが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4507,
+    "usage": {
+      "prompt": 621,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 746
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1281",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が神経障害性疼痛モデルであり、うつ病の動物モデルではない。文中の'depression'はC線維誘発電位の抑制（生理学的抑制）を指しており、うつ病とは無関係。"
+    ],
+    "durationMs": 6494,
+    "usage": {
+      "prompt": 794,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 980
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1282",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、チアミンとチアミナーゼ活性に関する研究である可能性が高い"
+    ],
+    "durationMs": 4019,
+    "usage": {
+      "prompt": 411,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 521
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1283",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ウサギ眼の角膜病変に関する研究である"
+    ],
+    "durationMs": 4347,
+    "usage": {
+      "prompt": 616,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 716
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1284",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がマウス乳癌細胞を用いたin vitro（試験管内）実験であり、in vivo（生体内）うつ病モデルではない"
+    ],
+    "durationMs": 4393,
+    "usage": {
+      "prompt": 1035,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 1149
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1285",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関するin vivo研究であり、うつ病（depression）が精神疾患として評価されている"
+    ],
+    "durationMs": 4742,
+    "usage": {
+      "prompt": 882,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 1013
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1286",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、ラット視床下部からのドーパミン放出メカニズムの基礎的研究である"
+    ],
+    "durationMs": 2838,
+    "usage": {
+      "prompt": 566,
+      "completion": 62,
+      "reasoning": 0,
+      "total": 628
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1287",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3849,
+    "usage": {
+      "prompt": 977,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 1075
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1288",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する用語が含まれておらず、研究対象がうつ病のin vivoモデルではないと判断される"
+    ],
+    "durationMs": 2922,
+    "usage": {
+      "prompt": 407,
+      "completion": 66,
+      "reasoning": 0,
+      "total": 473
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1289",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経可塑性における長期抑圧（LTD）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5373,
+    "usage": {
+      "prompt": 529,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 682
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1290",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 3947,
+    "usage": {
+      "prompt": 906,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 1003
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1291",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、メトキシクロルによるテストステロンレベルへの影響を調べた研究である"
+    ],
+    "durationMs": 7752,
+    "usage": {
+      "prompt": 821,
+      "completion": 228,
+      "reasoning": 0,
+      "total": 1049
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1292",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「depression（うつ病）」という語が含まれておらず、抄録が存在しないため、うつ病の動物モデルに関する研究かどうか判断できない。ただし、タイトルから脳やラットの加齢に関する研究であり、うつ病と関連する可能性は極めて低いと推測される。"
+    ],
+    "durationMs": 3716,
+    "usage": {
+      "prompt": 405,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 504
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1293",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivoマイクロダイアリシス実験が行われており、うつ病の動物モデル研究である"
+    ],
+    "durationMs": 3920,
+    "usage": {
+      "prompt": 743,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 849
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1294",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ヒト以外の生物（ハエ）を対象とした成長に関する研究である"
+    ],
+    "durationMs": 4238,
+    "usage": {
+      "prompt": 413,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 527
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1295",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、ミトコンドリアプロトンポンプの生化学的メカニズムに関する研究である"
+    ],
+    "durationMs": 5491,
+    "usage": {
+      "prompt": 772,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 926
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1296",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は運動抑制や感覚抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 6627,
+    "usage": {
+      "prompt": 732,
+      "completion": 190,
+      "reasoning": 0,
+      "total": 922
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1297",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2445,
+    "usage": {
+      "prompt": 419,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 472
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1298",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が猫（動物）であるが、うつ病モデルではなく、MPTPによるドパミン作動系損傷モデルであり、「うつ病」に言及していない"
+    ],
+    "durationMs": 5656,
+    "usage": {
+      "prompt": 614,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 762
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1299",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ニコチン耐性をラットで評価した研究である"
+    ],
+    "durationMs": 3773,
+    "usage": {
+      "prompt": 400,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 501
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1300",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく近親交配による適応度低下（inbreeding depression）を指している",
+      "対象がマウスの遺伝的多様性と近親交配の影響であり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 6357,
+    "usage": {
+      "prompt": 690,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 868
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1301",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病のin vivoモデルに関する動物実験であり、ヒト研究や呼吸・心機能の抑制とは無関係である"
+    ],
+    "durationMs": 6494,
+    "usage": {
+      "prompt": 597,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 782
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1302",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、ウサギの胆のうにおけるナトリウムおよび水分再吸収に関する生理学的研究である"
+    ],
+    "durationMs": 2806,
+    "usage": {
+      "prompt": 875,
+      "completion": 63,
+      "reasoning": 0,
+      "total": 938
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1303",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、甲状腺ホルモンとミトコンドリア機能に関する動物実験である"
+    ],
+    "durationMs": 2655,
+    "usage": {
+      "prompt": 628,
+      "completion": 58,
+      "reasoning": 0,
+      "total": 686
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1304",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3635,
+    "usage": {
+      "prompt": 813,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 909
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1305",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルではなく、てんかんおよび皮質スライスを用いたin vitro研究である。「depression」は「spreading depression（拡がり性抑制）」を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6275,
+    "usage": {
+      "prompt": 771,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 956
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1306",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "Wistar-Kyotoラットはうつ病の動物モデルとして広く用いられており、本研究はその神経内分泌異常と行動特性を調査しているため、in vivoうつ病モデル研究に該当する"
+    ],
+    "durationMs": 5228,
+    "usage": {
+      "prompt": 851,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 998
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1307",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病関連の動物実験であり、in vivoモデルに該当する"
+    ],
+    "durationMs": 5042,
+    "usage": {
+      "prompt": 660,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 797
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1308",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（ラットまたはマウスの社会的隔離ストレス）を用いた研究であり、in vivoでのうつ関連行動を評価している"
+    ],
+    "durationMs": 7710,
+    "usage": {
+      "prompt": 649,
+      "completion": 232,
+      "reasoning": 0,
+      "total": 881
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1309",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病モデルの動物実験であり、ヒト研究や呼吸・循環器系の「depression」とは無関係である"
+    ],
+    "durationMs": 5883,
+    "usage": {
+      "prompt": 788,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 953
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1310",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、前立腺芽形成に関する動物実験である"
+    ],
+    "durationMs": 3942,
+    "usage": {
+      "prompt": 706,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 807
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1311",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、心臓の機能抑制（心拍抑制）に関する研究である"
+    ],
+    "durationMs": 5971,
+    "usage": {
+      "prompt": 531,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 679
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1312",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性も排除できないが、そもそも「depression」という語がタイトルに現れていない"
+    ],
+    "durationMs": 3621,
+    "usage": {
+      "prompt": 405,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 498
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1313",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や心臓の抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4914,
+    "usage": {
+      "prompt": 1022,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 1162
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1314",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が麻酔による脳活動の抑制（depression of brain activity）を指しており、うつ病（depression as a psychiatric disorder）の動物モデルではない",
+      "研究対象はラットだが、うつ病モデルではなく麻酔下の生理反応を評価している"
+    ],
+    "durationMs": 5641,
+    "usage": {
+      "prompt": 786,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 946
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1315",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はリポソームの相転移における物理的「低下（depression）」を指しており、うつ病（depression）とは無関係である。動物実験は尿路感染症モデルであり、うつ病モデルではない。"
+    ],
+    "durationMs": 6891,
+    "usage": {
+      "prompt": 767,
+      "completion": 198,
+      "reasoning": 0,
+      "total": 965
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1316",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病モデルではなく、MPTPによるパーキンソン病モデルのマウスであり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5227,
+    "usage": {
+      "prompt": 570,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 720
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1317",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心筋抑制など、うつ病とは無関係な文脈で使用されている",
+      "対象がイヌの心室筋であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 6227,
+    "usage": {
+      "prompt": 553,
+      "completion": 181,
+      "reasoning": 0,
+      "total": 734
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1318",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（gerbil foot tap model）を用いたin vivo研究であり、対象とする動物実験に該当する"
+    ],
+    "durationMs": 4044,
+    "usage": {
+      "prompt": 610,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 721
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1319",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトの薬物中毒事例であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 6231,
+    "usage": {
+      "prompt": 585,
+      "completion": 180,
+      "reasoning": 0,
+      "total": 765
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1320",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデル（マウスおよびラット）を用いた研究であり、ヒト研究ではないため"
+    ],
+    "durationMs": 10218,
+    "usage": {
+      "prompt": 842,
+      "completion": 306,
+      "reasoning": 0,
+      "total": 1148
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1321",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4033,
+    "usage": {
+      "prompt": 708,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 811
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1322",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓機能の抑制（心筋抑制）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4577,
+    "usage": {
+      "prompt": 570,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 690
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1323",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であるという根拠がない"
+    ],
+    "durationMs": 2205,
+    "usage": {
+      "prompt": 397,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 448
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1324",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、ミトコンドリアによるジスルフィド還元のメカニズムを調べた生化学的研究である"
+    ],
+    "durationMs": 2757,
+    "usage": {
+      "prompt": 676,
+      "completion": 66,
+      "reasoning": 0,
+      "total": 742
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1325",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルがうつ病とは無関係であり、動物モデルに関する記述もない"
+    ],
+    "durationMs": 3508,
+    "usage": {
+      "prompt": 398,
+      "completion": 92,
+      "reasoning": 0,
+      "total": 490
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1326",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が細胞膜電位の抑制を指しており、うつ病モデルではない",
+      "うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4566,
+    "usage": {
+      "prompt": 757,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 875
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1327",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や心臓の機能低下ではなく、造血機能の抑制（hematopoietic depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4797,
+    "usage": {
+      "prompt": 643,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 761
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1328",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は混合リンパ球反応の抑制（免疫抑制）を指しており、うつ病モデルではない",
+      "対象はラットだが、うつ病のin vivoモデルに関する研究ではない",
+      "呼吸性や心臓性の抑制ではなく免疫学的抑制を指しているが、それでもうつ病とは無関係"
+    ],
+    "durationMs": 5340,
+    "usage": {
+      "prompt": 863,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 1015
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1329",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "非ヒト霊長類（アカゲザル）を用いたうつ病様行動のin vivo動物研究であり、対象がヒトでなく、呼吸や循環の抑制を指すものでもない"
+    ],
+    "durationMs": 6258,
+    "usage": {
+      "prompt": 667,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 849
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1330",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「Human」（ヒト）と明記されており、動物モデルの研究ではないため除外"
+    ],
+    "durationMs": 3737,
+    "usage": {
+      "prompt": 405,
+      "completion": 87,
+      "reasoning": 0,
+      "total": 492
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1331",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性軽度ストレス（CMS）を用いたうつ病様行動の動物モデル研究であり、対象がマウス（BI-1ノックアウトおよび野生型）であるため、in vivo うつ病モデルの研究に該当する。"
+    ],
+    "durationMs": 6985,
+    "usage": {
+      "prompt": 713,
+      "completion": 190,
+      "reasoning": 0,
+      "total": 903
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1332",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、ラット肝ミクロソームにおける脂質過酸化の阻害メカニズムに関する生化学的研究である"
+    ],
+    "durationMs": 3082,
+    "usage": {
+      "prompt": 780,
+      "completion": 66,
+      "reasoning": 0,
+      "total": 846
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1333",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であるという根拠がない",
+      "「depression」が呼吸抑制や循環抑制を指す可能性がある文脈（心血管作用）だが、そもそも「depression」という語が出現していない"
+    ],
+    "durationMs": 3426,
+    "usage": {
+      "prompt": 405,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 496
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1334",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト以外の動物（イヌ）ではあるが、研究テーマが心筋虚血や心臓の電気生理に関するものであり、うつ病（depression）の研究ではない。「depression」が心電図のST depression（ST低下）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6058,
+    "usage": {
+      "prompt": 767,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 941
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1335",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒツジを用いた繁殖行動に関する研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4136,
+    "usage": {
+      "prompt": 863,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 974
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1336",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（ラット）を対象とした研究であり、ヒト研究ではない。うつ病は呼吸抑制や心機能低下ではなく、行動面での抑うつ状態を指している。"
+    ],
+    "durationMs": 4741,
+    "usage": {
+      "prompt": 492,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 612
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1337",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病のin vivo動物モデルに関する記述が確認できない",
+      "「depression」の用語が含まれておらず、対象が動物研究かどうかも不明"
+    ],
+    "durationMs": 3107,
+    "usage": {
+      "prompt": 403,
+      "completion": 69,
+      "reasoning": 0,
+      "total": 472
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1338",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく心機能の低下（cardiac depression）を指している",
+      "対象は高血圧ラットの心筋機能に関する研究であり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4340,
+    "usage": {
+      "prompt": 921,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 1041
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1339",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4328,
+    "usage": {
+      "prompt": 712,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 832
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1340",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3911,
+    "usage": {
+      "prompt": 407,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 500
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1341",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅覚球切除マウスを用いたうつ病の動物モデルに関する研究であり、in vivo動物実験であるため"
+    ],
+    "durationMs": 6025,
+    "usage": {
+      "prompt": 772,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 948
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1342",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する動物実験であり、強制泳泳試験と尾懸垂試験で抗うつ様効果を評価している"
+    ],
+    "durationMs": 7250,
+    "usage": {
+      "prompt": 705,
+      "completion": 211,
+      "reasoning": 0,
+      "total": 916
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1343",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "うつ病（depression）に言及していない"
+    ],
+    "durationMs": 2196,
+    "usage": {
+      "prompt": 488,
+      "completion": 47,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1344",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（ventilatory depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5699,
+    "usage": {
+      "prompt": 562,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 710
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1345",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒツジであり、うつ病のin vivoモデルに関する研究ではない。また、「depression」はプロラクチン濃度の低下を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5255,
+    "usage": {
+      "prompt": 663,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 806
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1346",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、P2X受容体の構造と機能に関するレビューである"
+    ],
+    "durationMs": 5406,
+    "usage": {
+      "prompt": 729,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 879
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1347",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「Depression」が補体活性の抑制（免疫学的抑制）を指しており、うつ病モデルではないと判断される",
+      "動物（マウス）を用いた研究ではあるが、対象が腫瘍移植後の補体活性であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4754,
+    "usage": {
+      "prompt": 401,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 534
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1348",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象はラットを用いた心血管系の研究であり、うつ病（depression）の動物モデルに関する研究ではない。「depression」が文中に現れる場合も、これは「収縮の抑制（depression of the maximal response）」など生理学的抑制を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 7751,
+    "usage": {
+      "prompt": 1266,
+      "completion": 218,
+      "reasoning": 0,
+      "total": 1484
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1349",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は免疫抑制による抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4256,
+    "usage": {
+      "prompt": 638,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 740
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1350",
+    "label_included": 0,
+    "include_probability": null,
+    "reasons": [],
+    "error": "fetch failed",
+    "durationMs": 40714
+  },
+  {
+    "ref_id": "Depression-SLIM-1351",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究ではなく、ラット膀胱の平滑筋収縮に対するセイヨウオトギリソウの影響をin vitroで評価した研究である。対象はうつ病そのものではなく、うつ病と尿失禁の関連に言及しているのみである。"
+    ],
+    "durationMs": 12897,
+    "usage": {
+      "prompt": 806,
+      "completion": 219,
+      "reasoning": 0,
+      "total": 1025
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1352",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、代わりに線条体におけるシナプス可塑性のメカニズムを調べた神経生理学的研究である。「depression」はシナプス抑制（tLTD）を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 5525,
+    "usage": {
+      "prompt": 1077,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 1229
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1353",
+    "label_included": 1,
+    "include_probability": 0.7,
+    "reasons": [
+      "タイトルに「rhesus monkeys（リスザルザル）」とあり、霊長類を用いたin vivo研究の可能性があるが、うつ病モデルかどうかは抄録がないため不明。レセルピンはうつ病モデル作成に使われることがあるが、社会行動への影響のみに焦点があるかは不明。感度重視のため仮に含める。"
+    ],
+    "durationMs": 5683,
+    "usage": {
+      "prompt": 402,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 556
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1354",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれているが、文脈は心筋収縮性の低下（心臓の抑制）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4417,
+    "usage": {
+      "prompt": 404,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 515
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1355",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が視覚皮質の抑制（cortical depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4392,
+    "usage": {
+      "prompt": 561,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 673
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1356",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（in vivo動物モデル）であり、うつ状態の研究を行っているため"
+    ],
+    "durationMs": 5129,
+    "usage": {
+      "prompt": 554,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 693
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1357",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（in vivo動物モデル）であり、抑うつ様行動を評価している明確な動物実験であるため"
+    ],
+    "durationMs": 6630,
+    "usage": {
+      "prompt": 689,
+      "completion": 189,
+      "reasoning": 0,
+      "total": 878
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1358",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病関連行動の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではないため"
+    ],
+    "durationMs": 6511,
+    "usage": {
+      "prompt": 771,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 946
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1359",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が肝星細胞（HSC）であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "「depression（うつ病）」という用語が一切使用されておらず、関連する神経精神疾患のモデルではない"
+    ],
+    "durationMs": 3875,
+    "usage": {
+      "prompt": 1096,
+      "completion": 87,
+      "reasoning": 0,
+      "total": 1183
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1360",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、腸閉塞の実験であり、うつ病とは無関係である"
+    ],
+    "durationMs": 4912,
+    "usage": {
+      "prompt": 657,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 796
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1361",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能低下（hemodynamic depression）を指しており、うつ病モデルではない",
+      "対象は心不全ラットであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5118,
+    "usage": {
+      "prompt": 948,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 1065
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1362",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験が含まれており、ヒト研究部分があっても動物実験部分が明確に記載されているため包括する"
+    ],
+    "durationMs": 5964,
+    "usage": {
+      "prompt": 623,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 780
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1363",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく動物（犬）であるが、うつ病のin vivoモデルではなく、学習された社会的反応の薬理学的影響を調べた研究であり、うつ病モデルとして明確に記載されていない"
+    ],
+    "durationMs": 7393,
+    "usage": {
+      "prompt": 589,
+      "completion": 211,
+      "reasoning": 0,
+      "total": 800
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1364",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット脳切片を用いたin vitro実験であり、in vivoモデルではない"
+    ],
+    "durationMs": 4761,
+    "usage": {
+      "prompt": 732,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 848
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1365",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性予測不能軽度ストレス（CUMS）を用いたラットのうつ病モデルに関する動物実験であり、うつ病の神経生物学的メカニズムを調べている"
+    ],
+    "durationMs": 6577,
+    "usage": {
+      "prompt": 730,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 921
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1366",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は抑うつ症状ではなく、一般的な抑うつ状態（無気力・元気消失）を指しており、うつ病の動物モデルの研究ではない",
+      "対象は野生動物（カンガルー）の中毒症例であり、うつ病の研究目的ではない"
+    ],
+    "durationMs": 5188,
+    "usage": {
+      "prompt": 730,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 870
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1367",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が呼吸抑制や代謝抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 3805,
+    "usage": {
+      "prompt": 468,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 565
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1368",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がリンパ節へのコロイド取り込みの抑制を指しており、うつ病モデルではない",
+      "がんモデルを用いた研究であり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4907,
+    "usage": {
+      "prompt": 554,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 682
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1369",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（レセルピン誘発うつ）に関するin vivo動物実験であり、対象とするうつ病は精神疾患としてのうつ病である"
+    ],
+    "durationMs": 5573,
+    "usage": {
+      "prompt": 734,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1370",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、皮質拡延性抑制（cortical spreading depression, CSD）という神経生理学的現象を指しており、呼吸抑制や心機能抑制と同様に除外対象となる"
+    ],
+    "durationMs": 5328,
+    "usage": {
+      "prompt": 892,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 1034
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1371",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や代謝抑制など、うつ病とは無関係な文脈で使用されている",
+      "うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4117,
+    "usage": {
+      "prompt": 742,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 852
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1372",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "霊長類（マカクザル）を用いたうつ病関連の動物実験であり、ヒト研究ではない"
+    ],
+    "durationMs": 7029,
+    "usage": {
+      "prompt": 613,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 795
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1373",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 3021,
+    "usage": {
+      "prompt": 405,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1374",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "Wistar-Kyotoラットをうつ病の動物モデルとして使用しており、in vivoのうつ病モデルに関する研究である"
+    ],
+    "durationMs": 4315,
+    "usage": {
+      "prompt": 640,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 758
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1375",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）のin vivoモデルに関する研究ではなく、小脳の長期抑圧（LTD）および学習・記憶障害に焦点を当てている"
+    ],
+    "durationMs": 6323,
+    "usage": {
+      "prompt": 712,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1376",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスおよびラットを用いたうつ病のin vivoモデルに関する動物実験であり、ヒト研究ではない"
+    ],
+    "durationMs": 5066,
+    "usage": {
+      "prompt": 646,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 776
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1377",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット心房筋細胞であり、うつ病のin vivoモデルではない。また、「depression」は心筋収縮力低下（cardiac depression）を指しており、精神疾患としてのうつ病とは無関係。"
+    ],
+    "durationMs": 5687,
+    "usage": {
+      "prompt": 713,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 863
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1378",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "「reserpinized rats」とあることから、うつ病の動物モデル（in vivo）を使用している可能性が高い。レセルピンはうつ病モデル作成に用いられる薬剤である。"
+    ],
+    "durationMs": 4904,
+    "usage": {
+      "prompt": 430,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 548
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1379",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動のin vivoモデルに関する動物実験であり、対象とするうつ病は精神疾患としてのうつ病である"
+    ],
+    "durationMs": 6374,
+    "usage": {
+      "prompt": 721,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 907
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1380",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、エタノール依存および離脱がカテコールアミンに与える影響を調べた研究であるため"
+    ],
+    "durationMs": 4464,
+    "usage": {
+      "prompt": 405,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1381",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデル研究であり、テールサスペンション試験および強制水泳試験で不動時間を評価している。ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない。"
+    ],
+    "durationMs": 7372,
+    "usage": {
+      "prompt": 668,
+      "completion": 213,
+      "reasoning": 0,
+      "total": 881
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1382",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制など生理的抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4372,
+    "usage": {
+      "prompt": 635,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 738
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1383",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病のin vivo動物モデルに関する記述が確認できない",
+      "タイトルはDNA依存性RNA合成の阻害剤に関するもので、うつ病研究とは無関係と判断される"
+    ],
+    "durationMs": 3543,
+    "usage": {
+      "prompt": 404,
+      "completion": 75,
+      "reasoning": 0,
+      "total": 479
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1384",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病様行動を評価したin vivo動物モデル（ラット）の研究であり、対象とするうつ病は呼吸抑制や循環抑制ではなく精神疾患としての抑うつを指している"
+    ],
+    "durationMs": 5370,
+    "usage": {
+      "prompt": 901,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 1040
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1385",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression, CSD）を指しており、これは神経生理学的な現象でありうつ病モデルではない"
+    ],
+    "durationMs": 6085,
+    "usage": {
+      "prompt": 751,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 912
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1386",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が「inbreeding depression（近交劣勢）」の文脈で使用されており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4272,
+    "usage": {
+      "prompt": 631,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 740
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1387",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は生産性の低下を指しており、うつ病の動物モデルに関する研究ではない",
+      "対象は家畜の栄養障害であり、精神疾患のin vivoモデルではない"
+    ],
+    "durationMs": 4647,
+    "usage": {
+      "prompt": 771,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 891
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1388",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸バーストや過酸化水素産生の低下を指しており、うつ病（depression）の動物モデルに関する研究ではない",
+      "研究対象は寄生虫感染マウスの腹腔滲出細胞の機能であり、うつ病の行動・神経生物学的評価ではない"
+    ],
+    "durationMs": 7280,
+    "usage": {
+      "prompt": 727,
+      "completion": 213,
+      "reasoning": 0,
+      "total": 940
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1389",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "動物モデル（CRTH2ノックアウトマウス）を用いてうつ病様行動を評価しており、in vivo動物研究である"
+    ],
+    "durationMs": 6421,
+    "usage": {
+      "prompt": 662,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 844
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1390",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルを用いた研究ではなく、薬理学的特性の一般的評価に焦点を当てている",
+      "「depression」がうつ病を指す記載はなく、心臓抑制（cardiac depression）など他の意味での「depression」に関する記述が含まれる可能性がある"
+    ],
+    "durationMs": 7822,
+    "usage": {
+      "prompt": 1094,
+      "completion": 206,
+      "reasoning": 0,
+      "total": 1300
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1391",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はうつ病ではなく、皮質拡延性抑制（spreading depression）を指しており、これは神経生理学的現象でありうつ病モデルではない"
+    ],
+    "durationMs": 5863,
+    "usage": {
+      "prompt": 605,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 767
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1392",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が行動の抑制（食欲行動の抑制）を指しており、うつ病モデルではない。対象は猫だが、うつ病のin vivoモデルに関する研究ではない。"
+    ],
+    "durationMs": 4617,
+    "usage": {
+      "prompt": 567,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 687
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1393",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5162,
+    "usage": {
+      "prompt": 535,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 673
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1394",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病治療の臨床試験であり、動物モデルの研究ではない"
+    ],
+    "durationMs": 4298,
+    "usage": {
+      "prompt": 542,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 657
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1395",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "心臓組織（ウサギ左心房）を用いた心血管系の研究であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 4408,
+    "usage": {
+      "prompt": 419,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1396",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的・視覚皮質におけるシナプス効力の抑制を指しており、うつ病（depression as a mood disorder）の動物モデルではない"
+    ],
+    "durationMs": 6448,
+    "usage": {
+      "prompt": 953,
+      "completion": 189,
+      "reasoning": 0,
+      "total": 1142
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1397",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoラットを用いたうつ病関連の神経薬理学的研究であり、動物モデルに基づく研究であるため"
+    ],
+    "durationMs": 4729,
+    "usage": {
+      "prompt": 915,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 1029
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1398",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない。研究対象は鶏胚網膜であり、うつ病とは無関係。"
+    ],
+    "durationMs": 5377,
+    "usage": {
+      "prompt": 506,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 656
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1399",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではない可能性が高い",
+      "「depression」が心臓抑制（cardiac depression）を指す可能性があるが、本タイトルでは明示されていないものの、内容が心臓機能に関するため対象外"
+    ],
+    "durationMs": 6627,
+    "usage": {
+      "prompt": 405,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 550
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1400",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象が原生動物（Tetrahymena pyriformis）であり、うつ病のin vivo動物モデルではない",
+      "うつ病の動物モデルに関する記述が全くない"
+    ],
+    "durationMs": 5524,
+    "usage": {
+      "prompt": 814,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 973
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1401",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、心血管作用を調べた研究である"
+    ],
+    "durationMs": 5337,
+    "usage": {
+      "prompt": 636,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 787
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1402",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が体重増加の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3523,
+    "usage": {
+      "prompt": 554,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 647
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1403",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象が生体動物モデル（モルモット仔）を用いたうつ病様行動の研究であり、ヒト研究や呼吸・循環系の抑制を意味する「depression」ではない"
+    ],
+    "durationMs": 6264,
+    "usage": {
+      "prompt": 654,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 821
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1404",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経科学における長期抑圧（long-term depression, LTD）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4565,
+    "usage": {
+      "prompt": 641,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 754
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1405",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、過活動膀胱治療薬の薬理学的評価に焦点を当てている",
+      "「depression」が出現しないか、出現しても呼吸抑制や心機能抑制などの文脈でないが、本抄録では「depression」自体が使用されていない",
+      "対象疾患は過活動膀胱であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 9494,
+    "usage": {
+      "prompt": 1056,
+      "completion": 272,
+      "reasoning": 0,
+      "total": 1328
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1406",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2339,
+    "usage": {
+      "prompt": 409,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 460
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1407",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が呼吸抑制（dyspnoea）や骨髄抑制（depression of bone marrow cell proliferation）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 4411,
+    "usage": {
+      "prompt": 777,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 897
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1408",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制を指しており、うつ病モデルではない。また、うつ病に関する記述は一切含まれていない。"
+    ],
+    "durationMs": 4031,
+    "usage": {
+      "prompt": 645,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 747
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1409",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、報酬系と薬物依存に焦点を当てた神経可塑性の研究である。「depression」は長期抑圧（LTD）を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 5865,
+    "usage": {
+      "prompt": 762,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 903
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1410",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病の行動モデル（強制泳泳試験および尾部懸垂試験）を評価しており、うつ病のin vivo動物モデルに関する研究である。"
+    ],
+    "durationMs": 5095,
+    "usage": {
+      "prompt": 839,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 979
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1411",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は細胞増殖率の低下を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3992,
+    "usage": {
+      "prompt": 611,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 716
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1412",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が摂食量の低下（depression of food intake）を指しており、うつ病モデルではない",
+      "呼吸抑制や心機能抑制など、うつ病以外の「depression」が使用されている",
+      "うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5171,
+    "usage": {
+      "prompt": 704,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 843
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1413",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルを対象とした研究ではなく、統合失調症関連のセンサリーモーターゲーティング（前パルス抑制）を調べた動物実験である"
+    ],
+    "durationMs": 5016,
+    "usage": {
+      "prompt": 737,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1414",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、肝臓の解毒機構と農薬の影響を調べた研究である"
+    ],
+    "durationMs": 2456,
+    "usage": {
+      "prompt": 621,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 674
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1415",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、単にモノアミンなどの投与による体温調節反応を調べたものである"
+    ],
+    "durationMs": 7691,
+    "usage": {
+      "prompt": 780,
+      "completion": 225,
+      "reasoning": 0,
+      "total": 1005
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1416",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が呼吸抑制や運動抑制など、うつ病以外の文脈で使用されており、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 5261,
+    "usage": {
+      "prompt": 526,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 635
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1417",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoうつ病モデルではなく、in vitroのマウスミクログリア細胞（BV2細胞）を用いた実験であるため"
+    ],
+    "durationMs": 4777,
+    "usage": {
+      "prompt": 759,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 890
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1418",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、魚の捕食行動の生体力学に関する研究である"
+    ],
+    "durationMs": 2319,
+    "usage": {
+      "prompt": 797,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 848
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1419",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能抑制などの文脈ではなく、宿主個体群の減少（host population depression）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 5012,
+    "usage": {
+      "prompt": 693,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 820
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1420",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoのうつ病モデル（ラットを用いた強制水泳試験）に関する動物実験であり、対象とする研究である"
+    ],
+    "durationMs": 5663,
+    "usage": {
+      "prompt": 730,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 893
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1421",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、心筋および骨格筋へのダントロレンナトリウムの影響を調べた研究である"
+    ],
+    "durationMs": 6483,
+    "usage": {
+      "prompt": 586,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 752
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1422",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、血圧反応と交感神経刺激に関する研究である"
+    ],
+    "durationMs": 6851,
+    "usage": {
+      "prompt": 725,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 922
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1423",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない。両生類の神経筋接合部におけるエタノールと二価陽イオンの影響を調べた研究であり、うつ病とは無関係である。"
+    ],
+    "durationMs": 5109,
+    "usage": {
+      "prompt": 413,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 554
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1424",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4245,
+    "usage": {
+      "prompt": 699,
+      "completion": 90,
+      "reasoning": 0,
+      "total": 789
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1425",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究について言及しており、in vivo モデルの使用が明記されているため"
+    ],
+    "durationMs": 4039,
+    "usage": {
+      "prompt": 613,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 716
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1426",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、テストステロン濃度の季節変動に関する研究である"
+    ],
+    "durationMs": 2384,
+    "usage": {
+      "prompt": 541,
+      "completion": 52,
+      "reasoning": 0,
+      "total": 593
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1427",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（ラット）を用いた行動評価（行動絶望テスト）が行われており、対象とするin vivoうつ病研究に該当する"
+    ],
+    "durationMs": 4920,
+    "usage": {
+      "prompt": 631,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 761
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1428",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトのうつ病に関する議論であり、in vivo動物モデルを対象とした研究ではない"
+    ],
+    "durationMs": 5889,
+    "usage": {
+      "prompt": 817,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 975
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1429",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、心筋虚血に関する犬の研究である",
+      "「depression」がSTセグメントの低下（心電図所見）を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 6696,
+    "usage": {
+      "prompt": 730,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 921
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1430",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、ヒト研究ではなく、呼吸・循環器系の抑制を意味する「depression」ではない"
+    ],
+    "durationMs": 5973,
+    "usage": {
+      "prompt": 774,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 944
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1431",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）や動物モデルに関する記述が全く含まれていない"
+    ],
+    "durationMs": 2179,
+    "usage": {
+      "prompt": 417,
+      "completion": 48,
+      "reasoning": 0,
+      "total": 465
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1432",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性があるが、本研究では「hippocampal theta activityの抑制」として使われており、うつ病（depression）の動物モデルに関する研究ではない。対象は猫であり動物研究ではあるが、うつ病モデルではない。"
+    ],
+    "durationMs": 5478,
+    "usage": {
+      "prompt": 536,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 683
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1433",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 3775,
+    "usage": {
+      "prompt": 787,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 884
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1434",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がDNA合成の抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3910,
+    "usage": {
+      "prompt": 567,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 668
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1435",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される",
+      "心筋虚血の実験モデルに関する研究であり、対象がうつ病ではない"
+    ],
+    "durationMs": 3166,
+    "usage": {
+      "prompt": 416,
+      "completion": 76,
+      "reasoning": 0,
+      "total": 492
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1436",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "抄録に動物モデルやin vivo実験に関する記述がなく、ヒト研究かin vitro研究の可能性があるため対象外と判断される"
+    ],
+    "durationMs": 4244,
+    "usage": {
+      "prompt": 973,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 1079
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1437",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢神経系の抑制状態（CNS depression）を指しており、うつ病モデルではない",
+      "うつ病関連の行動評価やうつ病モデル動物の使用が記載されていない"
+    ],
+    "durationMs": 5129,
+    "usage": {
+      "prompt": 832,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 970
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1438",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac contractility depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 7251,
+    "usage": {
+      "prompt": 689,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 838
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1439",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、電気けいれん療法による神経興奮の影響を調べた研究である",
+      "「depression（うつ病）」に関する研究ではない"
+    ],
+    "durationMs": 5250,
+    "usage": {
+      "prompt": 678,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 811
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1440",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4822,
+    "usage": {
+      "prompt": 625,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 760
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1441",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能低下などの文脈ではなく、うつ病モデルを指している可能性があるか確認したが、本研究では「synaptic depression（シナプス抑制）」という神経生理学的現象を指しており、うつ病の動物モデルではない。また、対象は聴覚脳幹のcalyx of Heldであり、うつ病関連の行動または病理モデルではない。"
+    ],
+    "durationMs": 5987,
+    "usage": {
+      "prompt": 640,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 812
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1442",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトであり、動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 5526,
+    "usage": {
+      "prompt": 903,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 1015
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1443",
+    "label_included": 0,
+    "include_probability": 0.3,
+    "reasons": [
+      "動物実験の記述が一部あるが、主にヒトの躁うつ病や行動障害に関する臨床的記述であり、うつ病のin vivo動物モデルを主眼とした研究ではない"
+    ],
+    "durationMs": 4704,
+    "usage": {
+      "prompt": 756,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 887
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1444",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の語が含まれておらず、うつ病の動物モデルに関する研究であるという根拠がない"
+    ],
+    "durationMs": 2670,
+    "usage": {
+      "prompt": 431,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 488
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1445",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "「行動性抑うつ（behavioral depression）」を評価した動物実験であり、うつ病のin vivoモデルとして関連する可能性があるため。呼吸性抑うつや心機能抑制などの他の意味での「depression」ではない。"
+    ],
+    "durationMs": 4975,
+    "usage": {
+      "prompt": 749,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 886
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1446",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく羊であるが、うつ病（depression）の動物モデルに関する研究ではなく、糖質コルチコイド投与によるホルモン変動や羊毛成長への影響を調べた研究である。抄録中の「depressed」は内分泌ホルモンの抑制を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6061,
+    "usage": {
+      "prompt": 638,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 803
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1447",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関するin vivo動物実験であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」でもない"
+    ],
+    "durationMs": 6320,
+    "usage": {
+      "prompt": 558,
+      "completion": 181,
+      "reasoning": 0,
+      "total": 739
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1448",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく羊であるが、うつ病（depression）の研究ではなく、腎臓における電解質排泄とバソプレシンの影響に関する研究であり、「depression」はナトリウム排泄の抑制（depression in the rate of excretion）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5983,
+    "usage": {
+      "prompt": 824,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 995
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1449",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がアルコール依存症の治療であり、うつ病のin vivoモデルに関する研究ではない。動物モデルに関する記述もアルコール摂取量に焦点を当てており、うつ病のモデルではない。"
+    ],
+    "durationMs": 6660,
+    "usage": {
+      "prompt": 573,
+      "completion": 198,
+      "reasoning": 0,
+      "total": 771
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1450",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、てんかん発症モデルに関する研究である"
+    ],
+    "durationMs": 5906,
+    "usage": {
+      "prompt": 716,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 881
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1451",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、血流の抑制（depression of blood flow）を指している。対象はラットだが、うつ病モデルではない。"
+    ],
+    "durationMs": 4683,
+    "usage": {
+      "prompt": 752,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 875
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1452",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が「長期抑圧（LTD: long-term depression）」という神経科学的用語として使われており、うつ病（depression）を指していない。また、うつ病の動物モデルに関する記述が全くない。"
+    ],
+    "durationMs": 4899,
+    "usage": {
+      "prompt": 740,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 875
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1453",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、ラットの排卵および性ホルモンレベルに関する研究である"
+    ],
+    "durationMs": 5383,
+    "usage": {
+      "prompt": 761,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 910
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1454",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「ラットにおける実験的抑うつ症候群」と明記されており、in vivo動物モデルを用いたうつ病研究であることが明確"
+    ],
+    "durationMs": 4008,
+    "usage": {
+      "prompt": 440,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 548
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1455",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「experimental animals」（実験動物）と明記されており、うつ病治療薬（三環系抗うつ薬）に関する動物実験であることが示唆されているため、in vivoうつ病モデルの研究と判断される"
+    ],
+    "durationMs": 4826,
+    "usage": {
+      "prompt": 415,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 541
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1456",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経科学における長期抑圧（long-term depression, LTD）を指しており、うつ病（depression）ではない",
+      "研究はin vivoではなくin vitro（脳スライス）を用いている"
+    ],
+    "durationMs": 6246,
+    "usage": {
+      "prompt": 1004,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 1178
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1457",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、視交叉上核におけるシナプス伝達の調節に関する研究である"
+    ],
+    "durationMs": 2712,
+    "usage": {
+      "prompt": 934,
+      "completion": 58,
+      "reasoning": 0,
+      "total": 992
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1458",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「depressed」や「depressant」として使用されているが、これは行動の抑制を指しており、うつ病モデルを対象とした研究ではない。また、うつ病（depression）の動物モデルに関する記述は一切ない。"
+    ],
+    "durationMs": 8568,
+    "usage": {
+      "prompt": 785,
+      "completion": 253,
+      "reasoning": 0,
+      "total": 1038
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1459",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「spreading-depression-like」という用語はうつ病（depression）を指しておらず、神経生理学的な現象である拡延性抑制（spreading depression）を意味している",
+      "対象はラット海馬スライスを用いたin vitro実験であり、in vivoモデルではない",
+      "うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 6855,
+    "usage": {
+      "prompt": 1157,
+      "completion": 203,
+      "reasoning": 0,
+      "total": 1360
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1460",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoマウスモデルを用いたうつ病研究が明記されているため"
+    ],
+    "durationMs": 4723,
+    "usage": {
+      "prompt": 670,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 786
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1461",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（人間）であり、動物モデルではないため除外"
+    ],
+    "durationMs": 5407,
+    "usage": {
+      "prompt": 1176,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 1328
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1462",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2259,
+    "usage": {
+      "prompt": 408,
+      "completion": 49,
+      "reasoning": 0,
+      "total": 457
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1463",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「long-term depression (LTD)」は神経科学におけるシナプス可塑性の用語であり、うつ病（depression）を指していない",
+      "呼吸抑制や心機能抑制などの「depression」と同様に、本研究の「depression」は病理的なうつ病モデルではない",
+      "うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 7021,
+    "usage": {
+      "prompt": 601,
+      "completion": 196,
+      "reasoning": 0,
+      "total": 797
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1464",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「amygdaloid-kindled rats」とあり、うつ病のin vivo動物モデルに関する研究であることが明確"
+    ],
+    "durationMs": 4307,
+    "usage": {
+      "prompt": 408,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 515
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1465",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "抄録に動物モデルまたはうつ病モデルに関する記述がなく、対象が不明であるが、うつ病モデルの研究とは明示されていない。また、「depression」の語が一切使われておらず、うつ病（depression）の研究である可能性が極めて低い。"
+    ],
+    "durationMs": 3685,
+    "usage": {
+      "prompt": 503,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 600
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1466",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3879,
+    "usage": {
+      "prompt": 791,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 891
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1467",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、うつ病（気分障害）を対象としている"
+    ],
+    "durationMs": 7466,
+    "usage": {
+      "prompt": 815,
+      "completion": 212,
+      "reasoning": 0,
+      "total": 1027
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1468",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "抄録に「in vivo」での5-HT取り込み阻害作用の評価が記載されており、うつ病の動物モデル研究であると判断される"
+    ],
+    "durationMs": 4544,
+    "usage": {
+      "prompt": 670,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 790
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1469",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はうつ病ではなく、他の疾患群の一例として言及されており、動物モデルを用いたうつ病の研究ではない"
+    ],
+    "durationMs": 4804,
+    "usage": {
+      "prompt": 1105,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 1236
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1470",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究は心筋虚血および血小板凝集に関するものであり、うつ病（depression）の動物モデルではない。「depression」という語は心電図所見の「S-T segment depression」にのみ現れ、これは呼吸抑制や心機能抑制などの文脈での用法であり、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5840,
+    "usage": {
+      "prompt": 1034,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 1192
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1471",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルを対象とした研究ではなく、うつ病様行動の評価が副次的かつ陰性結果であるため"
+    ],
+    "durationMs": 4818,
+    "usage": {
+      "prompt": 736,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 871
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1472",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトの疾患（クロイツフェルト・ヤコブ病）に関する研究であり、動物モデルを用いたうつ病の研究ではない"
+    ],
+    "durationMs": 6149,
+    "usage": {
+      "prompt": 664,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 827
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1473",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、拡延性抑制（spreading depression）を指しており、うつ病の動物モデルではないため"
+    ],
+    "durationMs": 5458,
+    "usage": {
+      "prompt": 618,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 772
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1474",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、対象が麻酔下の犬であり、うつ病のin vivoモデルに関する動物研究ではないと判断される"
+    ],
+    "durationMs": 5140,
+    "usage": {
+      "prompt": 408,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 531
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1475",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、高血圧ラットを用いた心血管反応の研究である",
+      "「depression」が呼吸抑制や循環抑制を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 6329,
+    "usage": {
+      "prompt": 702,
+      "completion": 184,
+      "reasoning": 0,
+      "total": 886
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1476",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する動物実験であり、うつ病行動および海馬神経新生への影響を評価している"
+    ],
+    "durationMs": 6383,
+    "usage": {
+      "prompt": 773,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 959
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1477",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または代謝性の酸性症に伴うシナプス機能の抑制を指しており、うつ病モデルではない",
+      "in vivoのうつ病動物モデルに関する記述が全くない",
+      "in vitro（ラット海馬スライス）実験であり、in vivoモデルではない"
+    ],
+    "durationMs": 9249,
+    "usage": {
+      "prompt": 836,
+      "completion": 272,
+      "reasoning": 0,
+      "total": 1108
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1478",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、長期抑圧（long-term depression, LTD）という神経科学的現象を指している",
+      "対象はラットの海馬スライスを用いたin vitro実験であり、in vivoモデルではない"
+    ],
+    "durationMs": 5948,
+    "usage": {
+      "prompt": 969,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 1143
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1479",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivo動物実験であり、うつ病モデルに関連する電気けいれんショック治療を評価している"
+    ],
+    "durationMs": 5566,
+    "usage": {
+      "prompt": 602,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 754
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1480",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能の抑制（cardiac depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3885,
+    "usage": {
+      "prompt": 618,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 715
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1481",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」が神経活動の抑制を指しており、うつ病モデルではない可能性が高い",
+      "in vivo動物モデルに関する記述がタイトルに含まれていない"
+    ],
+    "durationMs": 4355,
+    "usage": {
+      "prompt": 408,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 515
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1482",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、研究対象がラット肝臓の細胞核であり、うつ病のin vivoモデルではないと判断される"
+    ],
+    "durationMs": 3178,
+    "usage": {
+      "prompt": 408,
+      "completion": 77,
+      "reasoning": 0,
+      "total": 485
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1483",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制など精神疾患としてのうつ病を指していない",
+      "対象が心臓機能の抑制（cardiotoxicity）に関する研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6074,
+    "usage": {
+      "prompt": 857,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 1027
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1484",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸バースト能の抑制を指しており、うつ病モデルではない",
+      "対象はマクロファージであり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 6801,
+    "usage": {
+      "prompt": 674,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 845
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1485",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした脳卒中後の疲労に関する観察研究であり、動物モデルを用いたうつ病研究ではない"
+    ],
+    "durationMs": 4391,
+    "usage": {
+      "prompt": 824,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 934
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1486",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット由来の脳スライスを用いたin vitro実験であり、in vivoモデルではない"
+    ],
+    "durationMs": 4767,
+    "usage": {
+      "prompt": 895,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 1013
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1487",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、糖尿病治療薬（経口血糖降下剤）に関する研究と推定されるため、うつ病のin vivo動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 3208,
+    "usage": {
+      "prompt": 419,
+      "completion": 82,
+      "reasoning": 0,
+      "total": 501
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1488",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2798,
+    "usage": {
+      "prompt": 406,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 459
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1489",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、胎児脳における神経新生のメカニズムを対象とした基礎研究である。「depression」は文中で疾患としてのうつ病を指しているが、本研究自体はうつ病モデルを用いておらず、関連性が不明瞭である。"
+    ],
+    "durationMs": 6273,
+    "usage": {
+      "prompt": 843,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 1025
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1490",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いた強制水泳試験といううつ病の動物モデルに関する研究であり、in vivoのうつ病モデルに該当する"
+    ],
+    "durationMs": 5432,
+    "usage": {
+      "prompt": 643,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 793
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1491",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「Behavioral depression in pigeons」とあり、動物（ハト）を用いたうつ病モデルの研究であることが明確"
+    ],
+    "durationMs": 3862,
+    "usage": {
+      "prompt": 402,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 503
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1492",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が抑うつではなく、脾臓機能の低下（hematologic functionのdepression）を指しており、うつ病の動物モデルの研究ではない"
+    ],
+    "durationMs": 4436,
+    "usage": {
+      "prompt": 654,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 773
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1493",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がレインボートラウト（魚類）であり、うつ病のin vivoモデルではない。また、「depression」が免疫細胞の機能抑制（phagocytic activityの低下）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 7529,
+    "usage": {
+      "prompt": 731,
+      "completion": 225,
+      "reasoning": 0,
+      "total": 956
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1494",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、小脳皮質のシナプス伝達に関する神経生理学的研究である"
+    ],
+    "durationMs": 4783,
+    "usage": {
+      "prompt": 764,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 888
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1495",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は長期抑性（LTD）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4044,
+    "usage": {
+      "prompt": 697,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 803
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1496",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が心電図所見の「ST depression（ST低下）」を指しており、うつ病モデルではない",
+      "研究は心臓のストレス応答と不整脈に焦点を当てており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5514,
+    "usage": {
+      "prompt": 775,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 908
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1497",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoマウスモデルを用いたうつ病関連行動の研究であり、動物実験である"
+    ],
+    "durationMs": 4325,
+    "usage": {
+      "prompt": 660,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 777
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1498",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が聴覚機能の抑制（AP depression）を指しており、うつ病（depression）の動物モデルではない",
+      "対象は脳幹・内耳の血流障害であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 5007,
+    "usage": {
+      "prompt": 590,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 724
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1499",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がマウス（MRL/ MpJおよびC57Bl/6J系統）を用いたin vivo動物実験であり、うつ病モデルに関する研究である"
+    ],
+    "durationMs": 6433,
+    "usage": {
+      "prompt": 863,
+      "completion": 181,
+      "reasoning": 0,
+      "total": 1044
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1500",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、膝関節の内側側副靱帯の発生過程に関する解剖学的研究である"
+    ],
+    "durationMs": 7061,
+    "usage": {
+      "prompt": 948,
+      "completion": 205,
+      "reasoning": 0,
+      "total": 1153
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1501",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動の評価に関する動物実験であり、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 5050,
+    "usage": {
+      "prompt": 825,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 962
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1502",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、神経生理学的活動の測定にとどまっている"
+    ],
+    "durationMs": 4042,
+    "usage": {
+      "prompt": 778,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1503",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病（depression）に関する研究ではなく、鶏の副腎皮質機能とアンドロゲンの関係を調べた動物実験である",
+      "「depression」が呼吸抑制や心機能抑制などを意味する文脈ではなく、そもそも「depression」という語が使用されていない"
+    ],
+    "durationMs": 3868,
+    "usage": {
+      "prompt": 893,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 993
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1504",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルを使用していない"
+    ],
+    "durationMs": 3959,
+    "usage": {
+      "prompt": 805,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 902
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1505",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、動物実験であるため"
+    ],
+    "durationMs": 6969,
+    "usage": {
+      "prompt": 826,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 1023
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1506",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3971,
+    "usage": {
+      "prompt": 754,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1507",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が感覚応答の抑制を指しており、うつ病モデルではない",
+      "呼吸性または心臓性の抑制ではなく感覚神経活動の抑制を指しているが、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5221,
+    "usage": {
+      "prompt": 664,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 797
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1508",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が神経障害性疼痛（allodynia）であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4680,
+    "usage": {
+      "prompt": 665,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 786
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1509",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "抄録に「depression」が精神疾患として言及されており、ラットを用いたin vivoおよびin vitroの神経細胞・ミクログリアにおけるTff3発現研究であり、うつ病の動物モデル関連の可能性があるため"
+    ],
+    "durationMs": 5353,
+    "usage": {
+      "prompt": 706,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 851
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1510",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経症状としての抑うつではなく、ウイルス感染による一般的な病態（元気消失など）を指している可能性が高い",
+      "うつ病の動物モデルに関する研究ではなく、ウイルス感染症の病態研究である"
+    ],
+    "durationMs": 4988,
+    "usage": {
+      "prompt": 645,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 784
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1511",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 6692,
+    "usage": {
+      "prompt": 600,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 791
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1512",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたin vivo動物実験であり、うつ病に関連する慢性ストレスモデルを検討しているため"
+    ],
+    "durationMs": 5664,
+    "usage": {
+      "prompt": 583,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 738
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1513",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される",
+      "「hypotensive effects（降圧作用）」に関する研究であり、うつ病とは無関係"
+    ],
+    "durationMs": 4680,
+    "usage": {
+      "prompt": 402,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 530
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1514",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性予測不能ストレス（CMS）を用いたラットを対象としたうつ病の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 5164,
+    "usage": {
+      "prompt": 722,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 859
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1515",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたin vivoモデルで、うつ病様症状と関連する慢性ストレス反応を評価しているため"
+    ],
+    "durationMs": 5560,
+    "usage": {
+      "prompt": 775,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 933
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1516",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、神経ネットワークと強化学習の計算モデルに関する理論的研究である"
+    ],
+    "durationMs": 2606,
+    "usage": {
+      "prompt": 717,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 772
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1517",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルを用いた研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 5977,
+    "usage": {
+      "prompt": 757,
+      "completion": 168,
+      "reasoning": 0,
+      "total": 925
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1518",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 5180,
+    "usage": {
+      "prompt": 762,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 907
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1519",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や心機能抑制などを指す可能性があるが、本研究では「long-term depression (LTD)」という神経科学の用語として使用されており、うつ病（depression）の動物モデルに関する研究ではない。また、うつ病やその動物モデルについて一切言及されていない。"
+    ],
+    "durationMs": 5199,
+    "usage": {
+      "prompt": 654,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 805
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1520",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 2491,
+    "usage": {
+      "prompt": 410,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 467
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1521",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象が繊毛虫（Blepharisma intermedium）であり、うつ病のin vivo動物モデルではない",
+      "「うつ病（depression）」という用語がタイトルや抄録に含まれておらず、呼吸性うつ病などの除外対象にも該当しないが、そもそもうつ病関連の研究ではない"
+    ],
+    "durationMs": 4205,
+    "usage": {
+      "prompt": 430,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 539
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1522",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経内分泌系の一時的な抑制（daily short-term depression of the neuroendrocrinium）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4300,
+    "usage": {
+      "prompt": 781,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 896
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1523",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病モデルに関する動物研究かどうか判断できないため、感度を優先して含める可能性あり"
+    ],
+    "durationMs": 2708,
+    "usage": {
+      "prompt": 406,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 465
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1524",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（ラットの社会的ストレスパラダイム）を用いたin vivo研究であり、対象がヒトでなく、呼吸・心機能の抑制を指すものでもない"
+    ],
+    "durationMs": 5352,
+    "usage": {
+      "prompt": 751,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 882
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1525",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」または動物モデルに関する記述がなく、骨代謝に関する研究であることが示唆されるため"
+    ],
+    "durationMs": 3901,
+    "usage": {
+      "prompt": 403,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 510
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1526",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指しており、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 4271,
+    "usage": {
+      "prompt": 532,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 650
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1527",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が運動活動の抑制を指しており、うつ病モデルではない",
+      "対象がオピオイド受容体の拮抗作用であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4381,
+    "usage": {
+      "prompt": 615,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 737
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1528",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "抄録に「depression」とあるが、それがうつ病を指すのか、または呼吸抑制などの他の意味か判断できない。また、動物モデルを使用している可能性はあるが、具体的な研究デザインやモデルに関する記述が抄録に含まれていないため、フルテキスト確認が必要。"
+    ],
+    "durationMs": 4936,
+    "usage": {
+      "prompt": 762,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 899
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1529",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や病態としての抑うつ状態を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5047,
+    "usage": {
+      "prompt": 745,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 875
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1530",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「central nervous system depressants」とあるが、これは抗うつ薬ではなく中枢神経抑制剤を指しており、うつ病モデル動物を用いた研究ではない可能性が高い。ただし、抄録がなく、全文確認なしでは完全な判断ができないため、低確率ながら含める可能性を残す。"
+    ],
+    "durationMs": 5338,
+    "usage": {
+      "prompt": 424,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 562
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1531",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がアルツハイマー病におけるうつ病の原因としての葉酸不足に言及しているが、動物モデルでのうつ病の評価や行動試験などの記述はなく、主にドラッグデリバリーシステムの物理化学的評価に焦点を当てている。また、ラットモデルは鼻腔吸収試験（ex-vivo perfusion）にのみ使用されており、うつ病のin vivoモデルとして用いられていない。"
+    ],
+    "durationMs": 9123,
+    "usage": {
+      "prompt": 834,
+      "completion": 269,
+      "reasoning": 0,
+      "total": 1103
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1532",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢神経系の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3935,
+    "usage": {
+      "prompt": 523,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 621
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1533",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫抑制（immunodepression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4883,
+    "usage": {
+      "prompt": 746,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 847
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1534",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、動物モデルのうつ病研究であることを示す根拠がない"
+    ],
+    "durationMs": 2795,
+    "usage": {
+      "prompt": 409,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 474
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1535",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心血管抑制（cardiovascular depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4434,
+    "usage": {
+      "prompt": 699,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 797
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1536",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制（growth depression）を指しており、うつ病（depression）ではない",
+      "対象が動物（ブタ）ではあるが、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4438,
+    "usage": {
+      "prompt": 643,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 761
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1537",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がネコであり、うつ病のin vivoモデルに関する研究ではない。また、「depression」が呼吸抑制や心機能抑制を指す可能性があるが、本抄録では「depression」という語自体が使用されていない。うつ病モデルに関する記述は一切ない。"
+    ],
+    "durationMs": 3886,
+    "usage": {
+      "prompt": 637,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 734
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1538",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトまたはヒトに近い霊長類（rhesus monkeys）であり、うつ病のin vivo動物モデル研究ではなく、不安気質（anxious temperament）の神経基盤に関する研究である。うつ病そのものをモデル化した研究ではない。"
+    ],
+    "durationMs": 6918,
+    "usage": {
+      "prompt": 686,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1539",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸・心臓機能の抑制ではなく、近交劣勢（inbreeding depression）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4786,
+    "usage": {
+      "prompt": 468,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 588
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1540",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が骨髄細胞数の減少（myelosuppression）を指しており、うつ病（depression）とは無関係である"
+    ],
+    "durationMs": 4637,
+    "usage": {
+      "prompt": 850,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 970
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1541",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデル（脳卒中後うつ病）に関するin vivo研究であり、対象が動物であるため"
+    ],
+    "durationMs": 6635,
+    "usage": {
+      "prompt": 758,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 928
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1542",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスおよびラットを用いたうつ病モデル（TSTおよびFST）での研究であり、in vivo動物実験であるため"
+    ],
+    "durationMs": 4382,
+    "usage": {
+      "prompt": 809,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 929
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1543",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（テトラベンアジン誘発性うつ状態）を評価しており、in vivo動物実験である"
+    ],
+    "durationMs": 4992,
+    "usage": {
+      "prompt": 560,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 683
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1544",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経のコリン感受性の低下（habituationの細胞アナログ）を指しており、うつ病モデルではない",
+      "対象はカタツムリ（Helix lucorum）の神経細胞であり、うつ病のin vivo動物モデルではない",
+      "呼吸性・心臓性うつではないが、精神疾患としての「うつ病」に関する研究ではない"
+    ],
+    "durationMs": 7838,
+    "usage": {
+      "prompt": 764,
+      "completion": 220,
+      "reasoning": 0,
+      "total": 984
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1545",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が体重減少（weight depression）を指しており、うつ病モデルではない",
+      "対象が鶏であり、うつ病のin vivoモデル研究ではない"
+    ],
+    "durationMs": 5722,
+    "usage": {
+      "prompt": 533,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 683
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1546",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラットであるが、うつ病モデルではなく、学習・記憶課題（水迷路）におけるセロトニン作動薬の影響を評価した研究である。うつ病のin vivoモデルに関する記述は一切含まれていない。"
+    ],
+    "durationMs": 5226,
+    "usage": {
+      "prompt": 745,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 892
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1547",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、動物実験であることが明確である"
+    ],
+    "durationMs": 5145,
+    "usage": {
+      "prompt": 781,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 920
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1548",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから、対象がラットの心臓であり、うつ病モデルではなく心臓機能への影響を調べていると判断される",
+      "「depression」が心臓抑制（cardiac depression）を意味する可能性が高く、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 4856,
+    "usage": {
+      "prompt": 404,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 538
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1549",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が不安行動モデルであり、うつ病のin vivoモデルではない。うつ病への言及は併存症状としての付随的なものにとどまる。"
+    ],
+    "durationMs": 6618,
+    "usage": {
+      "prompt": 709,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 895
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1550",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、シナプスの長期抑圧（Long-Term Depression, LTD）を指している",
+      "呼吸性または心臓性の抑制ではないが、神経生理学的現象であり、うつ病モデルではない"
+    ],
+    "durationMs": 7388,
+    "usage": {
+      "prompt": 558,
+      "completion": 214,
+      "reasoning": 0,
+      "total": 772
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1551",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく小脳の長期抑圧（long-term depression, LTD）を指しており、精神疾患の動物モデルではない"
+    ],
+    "durationMs": 4787,
+    "usage": {
+      "prompt": 824,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 958
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1552",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "Flinders Sensitive Line (FSL)ラットはうつ病の動物モデルとして広く用いられており、本研究はin vivo動物実験である"
+    ],
+    "durationMs": 6699,
+    "usage": {
+      "prompt": 504,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 695
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1553",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデルに関する研究であり、対象文献の抄録に明確に記載されている"
+    ],
+    "durationMs": 5729,
+    "usage": {
+      "prompt": 576,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 735
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1554",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性予測不能軽度ストレス（CUMS）によるうつ病モデルラットを用いたin vivo動物実験であり、呼吸性・心臓性の「depression」ではない"
+    ],
+    "durationMs": 8100,
+    "usage": {
+      "prompt": 796,
+      "completion": 238,
+      "reasoning": 0,
+      "total": 1034
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1555",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病関連の動物実験であり、in vivoモデルであることが明記されている"
+    ],
+    "durationMs": 4018,
+    "usage": {
+      "prompt": 515,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 613
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1556",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が肝臓ビタミンAの低下を指しており、うつ病モデルではない",
+      "ヒトおよびラットでの薬物代謝研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4733,
+    "usage": {
+      "prompt": 572,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 694
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1557",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が絶滅危惧種の鳥類（スペインオオワシ）であり、うつ病のin vivo動物モデルに関する研究ではない",
+      "「depression」が「inbreeding depression（近交劣勢）」を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 4978,
+    "usage": {
+      "prompt": 749,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 890
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1558",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経生理学的な抑制を指しており、うつ病モデルではない",
+      "in vivo ではなく in vitro（ラット海馬スライス）の実験である"
+    ],
+    "durationMs": 5927,
+    "usage": {
+      "prompt": 530,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 695
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1559",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の言及がなく、うつ病の動物モデルに関する研究ではないと判断される",
+      "マウス白血病細胞を用いたin vitro研究であり、in vivoモデルではない"
+    ],
+    "durationMs": 4632,
+    "usage": {
+      "prompt": 416,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1560",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、子宮収縮の抑制を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 7221,
+    "usage": {
+      "prompt": 923,
+      "completion": 194,
+      "reasoning": 0,
+      "total": 1117
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1561",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される",
+      "「in vitro」の心筋組織呼吸に関する研究であり、in vivoのうつ病モデルではない"
+    ],
+    "durationMs": 5279,
+    "usage": {
+      "prompt": 406,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 536
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1562",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が犬（動物）であるが、'depression'は抑うつ症状ではなく、全身状態の落ち込み（精神活動の抑制）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4733,
+    "usage": {
+      "prompt": 653,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 770
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1563",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象が生体内（in vivo）のラットを用いたうつ病モデルの研究であり、動物実験であることが明確である"
+    ],
+    "durationMs": 6879,
+    "usage": {
+      "prompt": 789,
+      "completion": 195,
+      "reasoning": 0,
+      "total": 984
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1564",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、対象がウシ（heifers）で呼吸・循環器系の「depression」を指す可能性も低いが、うつ病の動物モデルに関する研究ではないと明確に判断できる"
+    ],
+    "durationMs": 5768,
+    "usage": {
+      "prompt": 409,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 561
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1565",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い",
+      "タイトルから呼吸器系または循環器系の薬理作用に関する研究と推測され、対象外の「depression」（例：呼吸抑制）に該当する可能性がある"
+    ],
+    "durationMs": 5489,
+    "usage": {
+      "prompt": 398,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 543
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1566",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病のin vivo動物モデルではなく、心筋組織における電気生理学的現象を調べたものである。「depression」は心臓の抑制（cardiac depression）を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6305,
+    "usage": {
+      "prompt": 706,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 885
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1567",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患がうつ病ではなく、関節炎および疼痛モデルである",
+      "「depression」が呼吸抑制（respiratory depression）を指しており、精神疾患としてのうつ病ではない"
+    ],
+    "durationMs": 6510,
+    "usage": {
+      "prompt": 690,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1568",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がサルの精子であり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 6712,
+    "usage": {
+      "prompt": 622,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 794
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1569",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能低下などの文脈ではなく、うつ病を指しているか不明だが、抄録中の「long-term depression」は神経科学における長期抑圧（LTD）を指しており、うつ病モデルの動物実験ではないと判断できる",
+      "対象は依存性行動の神経メカニズムに関する動物研究であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5899,
+    "usage": {
+      "prompt": 525,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 697
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1570",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（ラット）を用いた研究であり、行動検査（強制泳ぎ試験）で抗うつ効果を評価している。人間を対象とした研究ではなく、呼吸抑制などの他の意味での「depression」ではない。"
+    ],
+    "durationMs": 7277,
+    "usage": {
+      "prompt": 866,
+      "completion": 192,
+      "reasoning": 0,
+      "total": 1058
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1571",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression, CSD）という神経生理学的現象を指しており、精神疾患の動物モデルではない"
+    ],
+    "durationMs": 4607,
+    "usage": {
+      "prompt": 963,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 1086
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1572",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、海馬のシナプス可塑性に関する神経生理学的研究である"
+    ],
+    "durationMs": 2792,
+    "usage": {
+      "prompt": 768,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 825
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1573",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4423,
+    "usage": {
+      "prompt": 799,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 914
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1574",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（ラット）を用いた研究であり、強制泳泳試験（forced swim test）を含む抑うつ様行動の評価を行っている"
+    ],
+    "durationMs": 8166,
+    "usage": {
+      "prompt": 717,
+      "completion": 235,
+      "reasoning": 0,
+      "total": 952
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1575",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、アルコール中毒ラットにおける肝脂質含量へのビタミンの影響を調べた研究である"
+    ],
+    "durationMs": 4756,
+    "usage": {
+      "prompt": 412,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 535
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1576",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（マウス）を用いた研究であり、ヒト研究ではない。また、うつ病（anhedoniaを含む）に関する研究で、呼吸抑制などの他の「depression」ではない。"
+    ],
+    "durationMs": 8518,
+    "usage": {
+      "prompt": 768,
+      "completion": 246,
+      "reasoning": 0,
+      "total": 1014
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1577",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は受容体部位の抑制を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4559,
+    "usage": {
+      "prompt": 675,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 795
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1578",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がアルツハイマー病モデルのマウスであり、うつ病のin vivoモデルではない",
+      "抄録中に「depression」とあるが、これは長期抑圧（long-term depression, LTD）という神経科学用語であり、うつ病を指していない"
+    ],
+    "durationMs": 7263,
+    "usage": {
+      "prompt": 794,
+      "completion": 182,
+      "reasoning": 0,
+      "total": 976
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1579",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「うつ病」や動物モデルに関する情報が含まれておらず、抄録が存在しないため、関連性を判断できない"
+    ],
+    "durationMs": 2639,
+    "usage": {
+      "prompt": 398,
+      "completion": 62,
+      "reasoning": 0,
+      "total": 460
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1580",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性または心臓性の抑制（収縮低下）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4510,
+    "usage": {
+      "prompt": 701,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 805
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1581",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「rats」（ラット）が含まれており、動物実験の可能性があるが、「depression」が含まれておらず、うつ病モデルかどうか不明であるため"
+    ],
+    "durationMs": 4353,
+    "usage": {
+      "prompt": 408,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 514
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1582",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5329,
+    "usage": {
+      "prompt": 711,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 851
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1583",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能抑制ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5647,
+    "usage": {
+      "prompt": 672,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 836
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1584",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸・循環などの生理的抑制を指しており、うつ病モデルではない",
+      "対象が血管内皮細胞のin vitro実験であり、in vivoうつ病モデルではない",
+      "動物実験ではあるが、うつ病の行動・神経生物学的モデルではない"
+    ],
+    "durationMs": 6167,
+    "usage": {
+      "prompt": 853,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 1008
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1585",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、近交劣勢（inbreeding depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 5577,
+    "usage": {
+      "prompt": 657,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 814
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1586",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は遺伝的近交うつや遠交うつを指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 6905,
+    "usage": {
+      "prompt": 723,
+      "completion": 183,
+      "reasoning": 0,
+      "total": 906
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1587",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は体重減少を指しており、うつ病モデルではない。対象はラットだが、うつ病のin vivoモデルに関する研究ではない。"
+    ],
+    "durationMs": 4432,
+    "usage": {
+      "prompt": 795,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 904
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1588",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではないため"
+    ],
+    "durationMs": 6839,
+    "usage": {
+      "prompt": 640,
+      "completion": 189,
+      "reasoning": 0,
+      "total": 829
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1589",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が抑うつではなく、腎乳頭ヒアルロン酸含量の「低下」を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4834,
+    "usage": {
+      "prompt": 857,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 981
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1590",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が生体内（in vivo）うつ病モデルではなく、計算機シミュレーションによる生体外（in silico）モデルである",
+      "「depression」はシナプスの抑制（long-term depression）を指しており、うつ病（depression disorder）ではない"
+    ],
+    "durationMs": 6396,
+    "usage": {
+      "prompt": 796,
+      "completion": 188,
+      "reasoning": 0,
+      "total": 984
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1591",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がフラミンゴの個体群における分散行動と遺伝的多様性の関連を調査しており、うつ病のin vivoモデルに関する研究ではない。"
+    ],
+    "durationMs": 4737,
+    "usage": {
+      "prompt": 678,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 792
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1592",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（ventilatory depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3966,
+    "usage": {
+      "prompt": 748,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 847
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1593",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」または「depression」に関する記述がなく、動物モデルを用いたうつ病研究であることを示す証拠がない"
+    ],
+    "durationMs": 3365,
+    "usage": {
+      "prompt": 409,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 474
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1594",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や神経活動の抑制（hypoxic depression of excitatory synaptic transmission）を指しており、うつ病モデルではない",
+      "in vivo うつ病動物モデルに関する研究ではない"
+    ],
+    "durationMs": 6050,
+    "usage": {
+      "prompt": 548,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 712
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1595",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病治療薬（リチウム）に関するin vivo動物実験であり、うつ病モデル研究に該当する"
+    ],
+    "durationMs": 6017,
+    "usage": {
+      "prompt": 576,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 741
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1596",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病のin vivo動物モデルであり、うつ病（精神疾患）に関する研究である"
+    ],
+    "durationMs": 7047,
+    "usage": {
+      "prompt": 1518,
+      "completion": 208,
+      "reasoning": 0,
+      "total": 1726
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1597",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、皮質拡延性抑制（cortical spreading depression）を指しており、これは神経生理学的現象でありうつ病モデルではない"
+    ],
+    "durationMs": 4271,
+    "usage": {
+      "prompt": 406,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 520
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1598",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、心臓の不整脈および自律神経活動に関する研究である"
+    ],
+    "durationMs": 6865,
+    "usage": {
+      "prompt": 903,
+      "completion": 202,
+      "reasoning": 0,
+      "total": 1105
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1599",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depressant action」とあるが、これは中枢神経抑制作用を指しており、うつ病モデルの研究ではない。対象はラットだが、うつ病のin vivoモデルに関する記述はなく、行動活動量の変化を観察しただけである。"
+    ],
+    "durationMs": 5648,
+    "usage": {
+      "prompt": 574,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 730
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1600",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルが法的・保険関連のテーマであり、動物モデルを用いたうつ病研究ではない"
+    ],
+    "durationMs": 5069,
+    "usage": {
+      "prompt": 440,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 582
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1601",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が心筋機能の低下（CPK depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない。対象は犬の心筋梗塞モデルであり、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5052,
+    "usage": {
+      "prompt": 790,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 927
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1602",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性軽度ストレス（CMS）を用いたラットを対象としたうつ病様行動の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制や心機能抑制などの「depression」とは無関係である。"
+    ],
+    "durationMs": 6481,
+    "usage": {
+      "prompt": 694,
+      "completion": 188,
+      "reasoning": 0,
+      "total": 882
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1603",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5242,
+    "usage": {
+      "prompt": 749,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 894
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1604",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivo実験であり、うつ病モデルに関連する記述（「depressogenic drugs」「psychiatric disorders in a form of depression」）が含まれるため"
+    ],
+    "durationMs": 6741,
+    "usage": {
+      "prompt": 554,
+      "completion": 195,
+      "reasoning": 0,
+      "total": 749
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1605",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 3700,
+    "usage": {
+      "prompt": 655,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 752
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1606",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "抄録に「mouse models of depression」を用いた動物実験が明記されており、うつ病のin vivoモデルに関する研究であるため"
+    ],
+    "durationMs": 4608,
+    "usage": {
+      "prompt": 1363,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 1486
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1607",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、シナプス可塑性の一種である長期抑圧（long-term depression, LTD）を指している",
+      "対象は動物（マウス）であるが、うつ病モデルではない"
+    ],
+    "durationMs": 6004,
+    "usage": {
+      "prompt": 676,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 852
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1608",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患が前立腺がんであり、うつ病のin vivoモデルに関する研究ではない"
+    ],
+    "durationMs": 4930,
+    "usage": {
+      "prompt": 913,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 1053
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1609",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が呼吸抑制や心機能抑制などではなく、うつ病を指しているか確認できないが、抄録の文脈から「depression of contractile function（収縮機能の低下）」と明確に記載されており、精神疾患としてのうつ病とは無関係と判断できる。また、研究対象はラット骨格筋であり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 7465,
+    "usage": {
+      "prompt": 717,
+      "completion": 204,
+      "reasoning": 0,
+      "total": 921
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1610",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や循環器の抑制ではなく、白血球数の減少を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 6667,
+    "usage": {
+      "prompt": 508,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 629
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1611",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が動物モデルを用いたうつ病研究ではなく、発生生物学に関するインタビューであり、うつ病は精神疾患としての言及にとどまり、in vivoモデルの研究ではない"
+    ],
+    "durationMs": 5182,
+    "usage": {
+      "prompt": 677,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 805
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1612",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能低下（E wave and E-to-A ratio depression）を指しており、うつ病モデルではない",
+      "対象は覚醒した犬の心機能に関する研究で、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 5076,
+    "usage": {
+      "prompt": 787,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 925
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1613",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトであり、動物モデルではないため除外"
+    ],
+    "durationMs": 4111,
+    "usage": {
+      "prompt": 643,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 752
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1614",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3820,
+    "usage": {
+      "prompt": 766,
+      "completion": 95,
+      "reasoning": 0,
+      "total": 861
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1615",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「spreading depression」は神経生理学的現象であり、うつ病（depression）の動物モデルではない",
+      "対象がハト（pigeon）であるが、うつ病モデルではなく脳波現象の研究"
+    ],
+    "durationMs": 4488,
+    "usage": {
+      "prompt": 404,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 529
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1616",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivo動物モデル（マウス）を用いたうつ病関連研究であり、ヒト研究や呼吸抑制などを指す「depression」ではない"
+    ],
+    "durationMs": 7364,
+    "usage": {
+      "prompt": 883,
+      "completion": 199,
+      "reasoning": 0,
+      "total": 1082
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1617",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4715,
+    "usage": {
+      "prompt": 946,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 1075
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1618",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が運動抑制（motor depression）を指しており、うつ病モデルではない",
+      "研究対象は神経障害性疼痛であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5166,
+    "usage": {
+      "prompt": 807,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 940
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1619",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はグルタチオン（GSH）の減少を指しており、うつ病モデルではない",
+      "対象は生殖毒性と変異原性に関する動物実験であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6383,
+    "usage": {
+      "prompt": 689,
+      "completion": 180,
+      "reasoning": 0,
+      "total": 869
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1620",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がロブスターの神経細胞であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3846,
+    "usage": {
+      "prompt": 860,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 957
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1621",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は血糖値の低下（respiratory depressionやcardiac depressionと同様の生理的抑制）を指しており、うつ病モデルではない",
+      "うつ病またはその動物モデルに関する記述が一切ない",
+      "対象はラットだが、うつ病関連の評価項目や行動試験が含まれていない"
+    ],
+    "durationMs": 5410,
+    "usage": {
+      "prompt": 646,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 799
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1622",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト細胞を用いたin vitro研究であり、うつ病のin vivo動物モデルを対象としていない"
+    ],
+    "durationMs": 4148,
+    "usage": {
+      "prompt": 633,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 743
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1623",
+    "label_included": 0,
+    "include_probability": 0.6,
+    "reasons": [
+      "タイトルに「rat brain」とあり、うつ病の動物モデル研究の可能性があるが、抄録がなく、うつ病との関連が明確でないため不確実"
+    ],
+    "durationMs": 4091,
+    "usage": {
+      "prompt": 405,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 510
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1624",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルを用いたうつ病の研究ではない"
+    ],
+    "durationMs": 5150,
+    "usage": {
+      "prompt": 996,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 1135
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1625",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病のin vivoモデルに関する研究であり、人間の研究ではなく、呼吸抑制などの他の意味での「depression」でもない"
+    ],
+    "durationMs": 6099,
+    "usage": {
+      "prompt": 774,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 939
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1626",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の語が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 2636,
+    "usage": {
+      "prompt": 403,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1627",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病治療に関する仮説および経験的報告であり、in vivo動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 5198,
+    "usage": {
+      "prompt": 786,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 925
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1628",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「central nervous system depressants」とあるが、これは「うつ病」モデルではなく中枢神経抑制作用を指す可能性が高く、動物モデルでのうつ病研究とは明確に異なる"
+    ],
+    "durationMs": 4246,
+    "usage": {
+      "prompt": 411,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 527
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1629",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がウシの卵母細胞であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 3797,
+    "usage": {
+      "prompt": 887,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 986
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1630",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "慢性予測不能軽度ストレス（CUMS）マウスモデルを用いたうつ病の動物実験であり、ヒト研究ではなく、呼吸・心機能の抑制など他の意味での「depression」ではない"
+    ],
+    "durationMs": 6278,
+    "usage": {
+      "prompt": 835,
+      "completion": 177,
+      "reasoning": 0,
+      "total": 1012
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1631",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "抄録に「depression」の記載がなく、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 2816,
+    "usage": {
+      "prompt": 780,
+      "completion": 52,
+      "reasoning": 0,
+      "total": 832
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1632",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、アルコール嗜好の抑制に関する研究である"
+    ],
+    "durationMs": 6165,
+    "usage": {
+      "prompt": 644,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 818
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1633",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2327,
+    "usage": {
+      "prompt": 400,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 451
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1634",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いた「学習性無力感」モデルによるうつ病のin vivo研究であり、明確に動物実験である"
+    ],
+    "durationMs": 5582,
+    "usage": {
+      "prompt": 769,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 920
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1635",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを対象としたin vivo研究であり、対象がラットであることが明記されている。うつ病が精神疾患として言及されており、呼吸性や心臓性の抑うつとは無関係である。"
+    ],
+    "durationMs": 7311,
+    "usage": {
+      "prompt": 779,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 976
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1636",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトの臨床試験であり、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4155,
+    "usage": {
+      "prompt": 595,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 701
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1637",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトまたは動物のうつ病モデルではなく、エタノールによる腸管吸収障害に関する研究である"
+    ],
+    "durationMs": 6188,
+    "usage": {
+      "prompt": 916,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 1090
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1638",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 5028,
+    "usage": {
+      "prompt": 696,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 821
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1639",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、鶏を用いた免疫応答の研究である"
+    ],
+    "durationMs": 4179,
+    "usage": {
+      "prompt": 725,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 837
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1640",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や行動の抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 3953,
+    "usage": {
+      "prompt": 854,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 952
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1641",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病のin vivo動物モデルであり、ヒト研究ではない。うつ病は精神疾患として扱われており、呼吸抑制などの他の意味での「depression」ではない。"
+    ],
+    "durationMs": 10156,
+    "usage": {
+      "prompt": 752,
+      "completion": 306,
+      "reasoning": 0,
+      "total": 1058
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1642",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がハエ（Musca domestica）であり、うつ病のin vivoモデルに関する研究ではない。うつ病に関する記述が全くない。"
+    ],
+    "durationMs": 2818,
+    "usage": {
+      "prompt": 696,
+      "completion": 64,
+      "reasoning": 0,
+      "total": 760
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1643",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が家畜（牛）であり、うつ病のin vivoモデルに関する研究ではない。",
+      "「depression」として言及されているのは摂食量の低下（生理的抑制）であり、精神疾患としてのうつ病ではない。"
+    ],
+    "durationMs": 5040,
+    "usage": {
+      "prompt": 807,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 938
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1644",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病様行動を評価するためにマウスを用いたin vivo動物実験であり、対象がヒトでなく、呼吸・心臓の抑制とは無関係"
+    ],
+    "durationMs": 5259,
+    "usage": {
+      "prompt": 755,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 900
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1645",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depressive substances」とあるが、これがうつ病（depression）を指すのか、他の生理的抑制（例：呼吸抑制）を指すのか不明であり、抄録がないため判断できない"
+    ],
+    "durationMs": 4332,
+    "usage": {
+      "prompt": 412,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1646",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅覚球切除マウスを用いたうつ病の動物モデルに関する研究であり、in vivo動物実験であるため"
+    ],
+    "durationMs": 5929,
+    "usage": {
+      "prompt": 564,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 712
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1647",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラット（in vivo動物モデル）を用いてうつ病関連の神経機構を検討しており、対象が動物研究であることが明確"
+    ],
+    "durationMs": 6855,
+    "usage": {
+      "prompt": 715,
+      "completion": 201,
+      "reasoning": 0,
+      "total": 916
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1648",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様行動のin vivoモデルに関する動物研究であり、ヒト研究や呼吸・心臓の抑制を意味する「depression」ではない"
+    ],
+    "durationMs": 7632,
+    "usage": {
+      "prompt": 800,
+      "completion": 218,
+      "reasoning": 0,
+      "total": 1018
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1649",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が血管収縮の抑制（生理学的抑制）を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病に関する研究ではない",
+      "対象は血管内皮細胞と脳底動脈であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5966,
+    "usage": {
+      "prompt": 664,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 831
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1650",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が心電図のT波低下（T wave depression）を指しており、うつ病（depression）とは無関係である。対象は心臓血管系の疾患モデルであり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 5493,
+    "usage": {
+      "prompt": 1002,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 1149
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1651",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病の動物モデルに関する研究ではない",
+      "「depression」が骨髄抑制を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 6604,
+    "usage": {
+      "prompt": 649,
+      "completion": 190,
+      "reasoning": 0,
+      "total": 839
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1652",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が循環器抑制（心血管抑制）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 4137,
+    "usage": {
+      "prompt": 908,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 1001
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1653",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、神経生理学的な応答の抑制（high frequency depression: HFD）を指しており、うつ病モデルではない。動物実験ではあるが、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 5434,
+    "usage": {
+      "prompt": 697,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 836
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1654",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象文献はラットを用いた強制水泳試験（FST）などの動物モデルでうつ病様行動を評価しており、in vivo動物研究であることが明確である。"
+    ],
+    "durationMs": 4477,
+    "usage": {
+      "prompt": 1460,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 1584
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1655",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様行動の動物モデルに関する研究であり、in vivoのうつ病モデルに該当する"
+    ],
+    "durationMs": 5886,
+    "usage": {
+      "prompt": 711,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 881
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1656",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 2517,
+    "usage": {
+      "prompt": 401,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 454
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1657",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 5105,
+    "usage": {
+      "prompt": 768,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 866
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1658",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」の明確な記載がなく、抄録が存在しないため、うつ病の動物モデル研究かどうか判断できない"
+    ],
+    "durationMs": 2853,
+    "usage": {
+      "prompt": 398,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 457
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1659",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（in vivo動物モデル）であり、うつ病モデルに関する研究である"
+    ],
+    "durationMs": 5180,
+    "usage": {
+      "prompt": 754,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 900
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1660",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、コカインによる免疫抑制およびウイルス感染の研究である"
+    ],
+    "durationMs": 3916,
+    "usage": {
+      "prompt": 674,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 779
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1661",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "対象が生態系の二酸化炭素フラックスに関する研究であり、うつ病のin vivo動物モデルを対象としていない",
+      "抄録中の'depression'は呼吸抑制など生理的抑制を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 5703,
+    "usage": {
+      "prompt": 840,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 995
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1662",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いた強制泳ぐテストによるうつ病モデルの動物実験であり、対象とするin vivoモデルのうつ病研究に該当する"
+    ],
+    "durationMs": 6216,
+    "usage": {
+      "prompt": 725,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 895
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1663",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、小脳における長期抑圧（long-term synaptic depression）という神経生理学的現象を指している"
+    ],
+    "durationMs": 5569,
+    "usage": {
+      "prompt": 623,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 777
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1664",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、胎児アルコール症候群と肝臓のタンパク質合成に関する研究である"
+    ],
+    "durationMs": 6751,
+    "usage": {
+      "prompt": 788,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 979
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1665",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（小児および青年）であり、動物モデルではないため"
+    ],
+    "durationMs": 4354,
+    "usage": {
+      "prompt": 957,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 1059
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1666",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルに関する研究について議論しており、in vivo モデルの文脈で記述されている"
+    ],
+    "durationMs": 5149,
+    "usage": {
+      "prompt": 502,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 636
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1667",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患が大腿骨頭壊死であり、うつ病（depression）の動物モデルではない。また、「depression」は本研究では「core decompression（減圧）」の文脈で使用されており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 7035,
+    "usage": {
+      "prompt": 827,
+      "completion": 189,
+      "reasoning": 0,
+      "total": 1016
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1668",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋抑制（myocardial depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4216,
+    "usage": {
+      "prompt": 750,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 853
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1669",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした無作為化比較試験であり、動物モデルを使用していないため"
+    ],
+    "durationMs": 5291,
+    "usage": {
+      "prompt": 706,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 839
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1670",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデルに関する研究であり、強制水泳試験（FST）で抗うつ様効果を評価している"
+    ],
+    "durationMs": 5714,
+    "usage": {
+      "prompt": 803,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 959
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1671",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関するin vivo研究であり、ヒト研究や呼吸・心臓の抑制を指す「depression」ではない"
+    ],
+    "durationMs": 5045,
+    "usage": {
+      "prompt": 805,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 944
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1672",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデルに関する研究であり、in vivo のうつ病モデルに該当する"
+    ],
+    "durationMs": 6559,
+    "usage": {
+      "prompt": 710,
+      "completion": 185,
+      "reasoning": 0,
+      "total": 895
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1673",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が使用されておらず、うつ病の動物モデルに関する研究ではない。また、「depressed」は細胞増殖の低下を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 4363,
+    "usage": {
+      "prompt": 508,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 625
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1674",
+    "label_included": 1,
+    "include_probability": 0.3,
+    "reasons": [
+      "「depressant effects」とあるが、これは中枢神経抑制作用を指しており、うつ病モデルの研究ではない可能性が高い。うつ病（depression）に関する明確な記述がなく、呼吸抑制や鎮静作用など他の「depression」の可能性もあるため、うつ病のin vivoモデル研究とは判断できない。"
+    ],
+    "durationMs": 5757,
+    "usage": {
+      "prompt": 596,
+      "completion": 161,
+      "reasoning": 0,
+      "total": 757
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1675",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い",
+      "タイトルから呼吸抑制や心機能抑制などの「depression」を指している可能性があるが、うつ病とは無関係と判断される"
+    ],
+    "durationMs": 4779,
+    "usage": {
+      "prompt": 396,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 524
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1676",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が神経伝達物質放出の抑制（持続的抑制）を指しており、うつ病モデルではない。対象はマウス運動神経終末だが、うつ病のin vivoモデルに関する研究ではない。"
+    ],
+    "durationMs": 5148,
+    "usage": {
+      "prompt": 587,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 719
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1677",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が使用されていない。また、対象は疼痛（nociception, hyperalgesia）に関する研究であり、うつ病（depression）の動物モデルではない。"
+    ],
+    "durationMs": 3080,
+    "usage": {
+      "prompt": 749,
+      "completion": 73,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1678",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が気分障害としてではなく、一般的な抑うつ状態または神経学的症状として使用されており、うつ病の動物モデルに関する研究ではない。また、研究対象は犬のリンパ腫および肺静脈奇形であり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 6358,
+    "usage": {
+      "prompt": 581,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 738
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1679",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory rate depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3997,
+    "usage": {
+      "prompt": 698,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 794
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1680",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病関連行動の動物実験であり、うつ病モデルとして適切である"
+    ],
+    "durationMs": 4726,
+    "usage": {
+      "prompt": 753,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 872
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1681",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が自然殺傷（NK）細胞の抑制を指しており、うつ病モデルではない",
+      "研究はがん転移の抑制に関するもので、うつ病のin vivoモデルを対象としていない"
+    ],
+    "durationMs": 5038,
+    "usage": {
+      "prompt": 864,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 996
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1682",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」の記載がなく、アレルギー反応に関する研究であることが示唆されている"
+    ],
+    "durationMs": 4852,
+    "usage": {
+      "prompt": 401,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 511
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1683",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病を指しているのではなく、運動活動に対する抑制（depressive action）を意味しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4540,
+    "usage": {
+      "prompt": 631,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 752
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1684",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がマウス（BALB/c）を用いたうつ病様行動の動物モデル研究であり、ヒト研究ではなく、呼吸・心臓の抑制を指す「depression」でもない"
+    ],
+    "durationMs": 5027,
+    "usage": {
+      "prompt": 783,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 921
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1685",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象が切除卵巣ラット（in vivo動物モデル）であり、うつ病様行動を評価しているため"
+    ],
+    "durationMs": 5638,
+    "usage": {
+      "prompt": 763,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 918
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1686",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」とあるが、これは抑うつ症状ではなく、一般的な病態（元気消失など）を指しており、うつ病の動物モデルに関する研究ではない。対象はキジで、呼吸器や脾臓のウイルス感染症（マーブル脾疾患）に関する報告である。"
+    ],
+    "durationMs": 4892,
+    "usage": {
+      "prompt": 510,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 645
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1687",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象が新生児ラットの動脈管拡張であり、うつ病（depression）の動物モデルではない。文中の 'respiratory depression' は呼吸抑制を指し、うつ病とは無関係。"
+    ],
+    "durationMs": 5436,
+    "usage": {
+      "prompt": 793,
+      "completion": 156,
+      "reasoning": 0,
+      "total": 949
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1688",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 3500,
+    "usage": {
+      "prompt": 404,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 457
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1689",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病様行動を評価する動物実験であり、in vivo モデルを使用している"
+    ],
+    "durationMs": 5935,
+    "usage": {
+      "prompt": 768,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 913
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1690",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来の細胞（ヒト単球由来マクロファージ）を用いたin vitro実験であり、in vivo動物モデルのうつ病研究ではない",
+      "「depression」は細胞性免疫の抑制（depression of cellular immunity）を指しており、精神疾患としてのうつ病ではない"
+    ],
+    "durationMs": 6564,
+    "usage": {
+      "prompt": 909,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 1100
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1691",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指しており、うつ病の動物モデルに関する研究ではない",
+      "対象はヒツジ（動物）であるが、うつ病モデルではない"
+    ],
+    "durationMs": 5228,
+    "usage": {
+      "prompt": 853,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 989
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1692",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がネコであり動物実験ではあるが、うつ病（depression）のモデルではなく、神経生理学的現象としての「抑制（depression）」を扱っている"
+    ],
+    "durationMs": 5408,
+    "usage": {
+      "prompt": 777,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 911
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1693",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病に関する記述もヒトの臨床症状であるため、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 5575,
+    "usage": {
+      "prompt": 633,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 790
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1694",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、成長豚における銅・モリブデン・硫化物の影響を調べた研究である"
+    ],
+    "durationMs": 4500,
+    "usage": {
+      "prompt": 412,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 532
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1695",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫抑制（immunodepression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4864,
+    "usage": {
+      "prompt": 755,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 856
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1696",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いた研究であり、in vivoマウス実験で感情・認知処理の機能不全を評価している"
+    ],
+    "durationMs": 7090,
+    "usage": {
+      "prompt": 851,
+      "completion": 210,
+      "reasoning": 0,
+      "total": 1061
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1697",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした臨床試験であり、動物モデルのうつ病研究ではない",
+      "「depression」は自然キラー細胞の減少を指しており、精神疾患としてのうつ病ではない"
+    ],
+    "durationMs": 7444,
+    "usage": {
+      "prompt": 804,
+      "completion": 221,
+      "reasoning": 0,
+      "total": 1025
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1698",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、神経シナプスにおける小胞リクルートメントのメカニズムに関する基礎神経科学的研究である"
+    ],
+    "durationMs": 4799,
+    "usage": {
+      "prompt": 738,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 870
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1699",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、排卵に関する研究である"
+    ],
+    "durationMs": 5004,
+    "usage": {
+      "prompt": 780,
+      "completion": 111,
+      "reasoning": 0,
+      "total": 891
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1700",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depressant effects」とあるが、これがうつ病（depression）モデルに関するものか、呼吸抑制や心機能抑制などの他の「depression」を指すか不明である。抄録がなく、動物モデルを使用しているか確認できない。"
+    ],
+    "durationMs": 4873,
+    "usage": {
+      "prompt": 399,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 527
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1701",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、学習機能の低下（learning depression）を指しており、呼吸抑制や心機能抑制と同様に除外対象となるため"
+    ],
+    "durationMs": 5792,
+    "usage": {
+      "prompt": 806,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 925
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1702",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が「血清アルカリホスファターゼ活性の低下（depression of serum alkaline phosphatase activity）」という生理学的抑制を指しており、うつ病（depression）とは無関係である。また、研究は吸入毒性試験であり、うつ病の動物モデルに関するものではない。"
+    ],
+    "durationMs": 5485,
+    "usage": {
+      "prompt": 889,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 1046
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1703",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたin vivoモデルで、社会的隔離ストレスによりうつ病様症状が悪化したと明記されており、動物のうつ病モデルに関する研究である"
+    ],
+    "durationMs": 4973,
+    "usage": {
+      "prompt": 853,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 982
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1704",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が猫の症例報告であり、うつ病のin vivo動物モデル研究ではない",
+      "「depression」という言葉は精神疾患としてのうつ病ではなく、抑うつ状態や元気消失を指している可能性が高い"
+    ],
+    "durationMs": 5328,
+    "usage": {
+      "prompt": 664,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 795
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1705",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、トリエチルスズによる脳浮腫の研究である"
+    ],
+    "durationMs": 6416,
+    "usage": {
+      "prompt": 766,
+      "completion": 177,
+      "reasoning": 0,
+      "total": 943
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1706",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（うつ病患者）であり、動物モデルではないため除外"
+    ],
+    "durationMs": 5055,
+    "usage": {
+      "prompt": 729,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 869
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1707",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象としたうつ病の遺伝関連研究であり、in vivo動物モデルを使用していない"
+    ],
+    "durationMs": 5215,
+    "usage": {
+      "prompt": 710,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 825
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1708",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来のセロトニントランスポーター（SERT）およびノルエピネフリントランスポーター（NET）を対象としており、in vivo動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 4768,
+    "usage": {
+      "prompt": 742,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 868
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1709",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関するin vivo動物実験であり、対象がヒトではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 5997,
+    "usage": {
+      "prompt": 609,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 767
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1710",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が小学校3年生の児童であり、ヒトを対象とした研究であるため"
+    ],
+    "durationMs": 4724,
+    "usage": {
+      "prompt": 641,
+      "completion": 110,
+      "reasoning": 0,
+      "total": 751
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1711",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が老化に伴う交感神経・副腎髄質機能の変化であり、うつ病モデルではない",
+      "「depression」という語は血圧受容器刺激に対する反射性抑制（reflex depression）を指しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 5735,
+    "usage": {
+      "prompt": 607,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 757
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1712",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（母親と子ども）であり、動物モデルではない"
+    ],
+    "durationMs": 4207,
+    "usage": {
+      "prompt": 548,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 657
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1713",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動のin vivoモデルに関する研究であり、動物実験であるため"
+    ],
+    "durationMs": 4793,
+    "usage": {
+      "prompt": 744,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 869
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1714",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓抑制（cardio-depressant）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4035,
+    "usage": {
+      "prompt": 818,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 924
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1715",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がウミウシ（Aplysia）を用いた学習・習慣化の神経機構に関する研究であり、うつ病（depression）のin vivo動物モデルではない。また、「depression」は本抄録で「homosynaptic depression」として神経生理学的抑制を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5954,
+    "usage": {
+      "prompt": 780,
+      "completion": 162,
+      "reasoning": 0,
+      "total": 942
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1716",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、腎機能とアドレナリン受容体に関する研究である"
+    ],
+    "durationMs": 6038,
+    "usage": {
+      "prompt": 677,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 844
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1717",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様行動の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」でもない"
+    ],
+    "durationMs": 5659,
+    "usage": {
+      "prompt": 748,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 912
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1718",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という言葉が神経活動の抑制（depressive effects）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5826,
+    "usage": {
+      "prompt": 647,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 767
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1719",
+    "label_included": 0,
+    "include_probability": 0.2,
+    "reasons": [
+      "「depressive effects」が呼吸抑制や鎮静など非うつ病関連の抑制効果を指している可能性が高い",
+      "うつ病の動物モデルに関する記述が明確に含まれていない",
+      "行動抑制や鎮静作用に関する記載であり、うつ病モデルとは判断できない"
+    ],
+    "durationMs": 7069,
+    "usage": {
+      "prompt": 603,
+      "completion": 206,
+      "reasoning": 0,
+      "total": 809
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1720",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する用語が含まれておらず、抄録が存在しないため、動物モデル研究かどうか判断できない"
+    ],
+    "durationMs": 2707,
+    "usage": {
+      "prompt": 395,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 460
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1721",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が生体内うつ病モデルではなく、マウス脳切片を用いたin vitro実験である",
+      "「depression」が神経活動の抑制（inhibitory activityのdepression）を指しており、うつ病を意味しない"
+    ],
+    "durationMs": 7348,
+    "usage": {
+      "prompt": 749,
+      "completion": 214,
+      "reasoning": 0,
+      "total": 963
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1722",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病様行動の動物モデル（学習性無力感）に関する研究であり、in vivo動物実験であるため"
+    ],
+    "durationMs": 5740,
+    "usage": {
+      "prompt": 527,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 691
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1723",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒト由来の好中球を用いた研究であり、動物モデルではないため除外"
+    ],
+    "durationMs": 4048,
+    "usage": {
+      "prompt": 753,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 844
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1724",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、生殖機能への影響を調べた動物研究である"
+    ],
+    "durationMs": 2479,
+    "usage": {
+      "prompt": 614,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 665
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1725",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が使用されているが、これは骨髄抑制による白血球減少（neutropenia）に伴う白血球数の「低下（depression of WBCs）」を指しており、うつ病（depression）の動物モデルではない",
+      "対象は化学療法誘発性好中球減少症のラットモデルであり、うつ病の研究ではない",
+      "うつ病（depression）に関連する行動、神経生化学的、または薬理学的評価が一切含まれていない"
+    ],
+    "durationMs": 7284,
+    "usage": {
+      "prompt": 1284,
+      "completion": 210,
+      "reasoning": 0,
+      "total": 1494
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1726",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の病因における背側縫線核と正中縫線核の差異的役割について言及しており、in vivoラットモデルを用いた研究である"
+    ],
+    "durationMs": 5943,
+    "usage": {
+      "prompt": 811,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 977
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1727",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「in vivo」および「rats」が含まれており、うつ病の動物モデルに関する研究であることが明確"
+    ],
+    "durationMs": 6134,
+    "usage": {
+      "prompt": 414,
+      "completion": 169,
+      "reasoning": 0,
+      "total": 583
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1728",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、胆汁分泌の低下（生理学的な抑制）を指している",
+      "対象はラットの肝移植モデルであり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 7215,
+    "usage": {
+      "prompt": 715,
+      "completion": 212,
+      "reasoning": 0,
+      "total": 927
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1729",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が統合失調症の治療に関する動物実験であり、うつ病モデルの研究ではない。うつ病は背景情報としてのみ言及され、主要な研究目的やモデルではない。"
+    ],
+    "durationMs": 6098,
+    "usage": {
+      "prompt": 758,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 930
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1730",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルではなく、培養ラット海馬ニューロン（in vitro）を用いた実験であるため、動物モデルのうつ病研究に該当しない"
+    ],
+    "durationMs": 4461,
+    "usage": {
+      "prompt": 621,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 739
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1731",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoうつ病モデルではなく、経皮吸収に関するin vitro実験である",
+      "マウスは生体モデルとして用いられておらず、マウス表皮を用いたin vitro試験である"
+    ],
+    "durationMs": 6845,
+    "usage": {
+      "prompt": 746,
+      "completion": 203,
+      "reasoning": 0,
+      "total": 949
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1732",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（妊産婦）であり、動物モデルの研究ではない"
+    ],
+    "durationMs": 4000,
+    "usage": {
+      "prompt": 694,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 802
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1733",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく、脳内の「spreading depression（拡張性抑制）」を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 6296,
+    "usage": {
+      "prompt": 648,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1734",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が計算モデル（in silico）であり、in vivo動物モデルを用いた実験研究ではない"
+    ],
+    "durationMs": 5410,
+    "usage": {
+      "prompt": 1023,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 1177
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1735",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、ヒト研究ではない。また、「depression」が呼吸抑制や心機能抑制などを指すものではない。"
+    ],
+    "durationMs": 5237,
+    "usage": {
+      "prompt": 689,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 837
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1736",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はカルシウム電流の抑制を指しており、うつ病モデルではない",
+      "研究対象はラットのラクトトロープ細胞であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5481,
+    "usage": {
+      "prompt": 956,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 1095
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1737",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的な電流の抑制（depression of currents）を指しており、うつ病モデルではない",
+      "うつ病（depression）のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5006,
+    "usage": {
+      "prompt": 763,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 897
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1738",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がin vitroの腫瘍性レイディグ細胞であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 5583,
+    "usage": {
+      "prompt": 909,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 1063
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1739",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や心機能抑制ではなく、シナプス伝達における短期抑制（short-term depression）を指しており、うつ病モデルではない",
+      "対象はラットの聴神経シナプス（calyx of Held）であり、うつ病のin vivo動物モデルではない"
+    ],
+    "durationMs": 5587,
+    "usage": {
+      "prompt": 750,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 909
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1740",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルが「うつ病」や動物モデルに関連する内容を含んでおらず、線溶と生殖に関するものであるため"
+    ],
+    "durationMs": 4188,
+    "usage": {
+      "prompt": 395,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 495
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1741",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ様行動（anhedoniaなど）の評価に関する動物実験であり、対象がin vivoモデルのうつ病研究である"
+    ],
+    "durationMs": 6629,
+    "usage": {
+      "prompt": 682,
+      "completion": 191,
+      "reasoning": 0,
+      "total": 873
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1742",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルを使用していない"
+    ],
+    "durationMs": 3606,
+    "usage": {
+      "prompt": 685,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 781
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1743",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する用語が含まれておらず、がん腫瘍に関する研究であることが示唆されているため、うつ病のin vivoモデルの研究ではないと判断される"
+    ],
+    "durationMs": 3417,
+    "usage": {
+      "prompt": 417,
+      "completion": 78,
+      "reasoning": 0,
+      "total": 495
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1744",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、牛の大動脈におけるトリグリセリドリパーゼ活性に関する生化学的研究である"
+    ],
+    "durationMs": 4163,
+    "usage": {
+      "prompt": 567,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 671
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1745",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（ラット）を用いた研究であり、in vivoのうつ病モデルに関する内容である"
+    ],
+    "durationMs": 8886,
+    "usage": {
+      "prompt": 712,
+      "completion": 257,
+      "reasoning": 0,
+      "total": 969
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1746",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 3551,
+    "usage": {
+      "prompt": 546,
+      "completion": 90,
+      "reasoning": 0,
+      "total": 636
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1747",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルからうつ病の動物モデルに関する研究ではないと判断できる。筋肉のグルコース取り込みを調べた研究であり、うつ病とは無関係である。"
+    ],
+    "durationMs": 4219,
+    "usage": {
+      "prompt": 402,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 518
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1748",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いた強制水泳テストといううつ病のin vivo動物モデルを用いた研究であり、ヒト研究や呼吸・心臓の抑制とは無関係である"
+    ],
+    "durationMs": 5687,
+    "usage": {
+      "prompt": 950,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 1110
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1749",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "非ヒト霊長類（マカク）を用いたうつ病モデルのin vivo研究であり、対象が動物であり、精神的うつ病を扱っている"
+    ],
+    "durationMs": 7308,
+    "usage": {
+      "prompt": 701,
+      "completion": 208,
+      "reasoning": 0,
+      "total": 909
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1750",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivo実験であり、強制泳ぐテスト（forced swim test）を含む行動評価によりうつ病様行動を評価しているため、うつ病の動物モデル研究に該当する。"
+    ],
+    "durationMs": 7827,
+    "usage": {
+      "prompt": 714,
+      "completion": 229,
+      "reasoning": 0,
+      "total": 943
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1751",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸・心機能・代謝などの抑制を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4445,
+    "usage": {
+      "prompt": 724,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 831
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1752",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット由来の甲状腺細胞株（FRTL-5）を用いたin vitro実験であり、in vivoうつ病モデルではない"
+    ],
+    "durationMs": 4834,
+    "usage": {
+      "prompt": 689,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 815
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1753",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病の動物モデルに関する研究ではない",
+      "「depression」はB細胞過反応の抑制を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 5902,
+    "usage": {
+      "prompt": 635,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 806
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1754",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルを対象とした研究ではなく、うつ病は併存症状としてのみ言及されている"
+    ],
+    "durationMs": 4352,
+    "usage": {
+      "prompt": 663,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 775
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1755",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「antidepressant potential」とあるが、動物実験かどうか不明であり、抄録が存在しないため判断できない"
+    ],
+    "durationMs": 4168,
+    "usage": {
+      "prompt": 395,
+      "completion": 99,
+      "reasoning": 0,
+      "total": 494
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1756",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いた慢性ストレス誘発性うつ病モデルに関する動物実験であり、うつ病の文脈が精神疾患であることが明確"
+    ],
+    "durationMs": 5324,
+    "usage": {
+      "prompt": 780,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 929
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1757",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象が生体内（in vivo）の動物モデルであり、うつ病関連の深部脳刺激（DBS）研究であることが明記されている。"
+    ],
+    "durationMs": 6910,
+    "usage": {
+      "prompt": 693,
+      "completion": 197,
+      "reasoning": 0,
+      "total": 890
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1758",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「renal sympathetic nerve activityの抑制（depression）」を指しており、うつ病（depression）の動物モデルではない",
+      "研究対象はうつ病ではなく、バロ受容体反射感受性と腎臓機能の関係である"
+    ],
+    "durationMs": 5199,
+    "usage": {
+      "prompt": 815,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 957
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1759",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸器疾患に関連する臨床症状として記載されており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4160,
+    "usage": {
+      "prompt": 787,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 900
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1760",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに動物実験やin vivoモデルに関する記述がなく、非侵襲的迷走神経刺激の開発・安全性・忍容性に関する研究と思われるため、ヒト研究の可能性が高い"
+    ],
+    "durationMs": 3317,
+    "usage": {
+      "prompt": 421,
+      "completion": 73,
+      "reasoning": 0,
+      "total": 494
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1761",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 2701,
+    "usage": {
+      "prompt": 805,
+      "completion": 40,
+      "reasoning": 0,
+      "total": 845
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1762",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や動物モデルに関する言及がなく、抄録が存在しないため、うつ病のin vivoモデル研究である可能性が極めて低い"
+    ],
+    "durationMs": 2763,
+    "usage": {
+      "prompt": 397,
+      "completion": 68,
+      "reasoning": 0,
+      "total": 465
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1763",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、水銀の保持と分布に関する研究である"
+    ],
+    "durationMs": 4174,
+    "usage": {
+      "prompt": 412,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 519
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1764",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、ラット海馬スライスを用いたin vitro電気生理学的実験である"
+    ],
+    "durationMs": 5464,
+    "usage": {
+      "prompt": 731,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1765",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、低体温症における体温への薬剤効果を調べた研究であるため"
+    ],
+    "durationMs": 4211,
+    "usage": {
+      "prompt": 411,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1766",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「in vivo」や「うつ病モデル」に関する記述がなく、対象がin vitroの悪性腫瘍であることが明記されているため、うつ病の動物モデル研究ではない"
+    ],
+    "durationMs": 4965,
+    "usage": {
+      "prompt": 409,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 528
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1767",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、生体外の酵素自溶に関する研究であると推測される"
+    ],
+    "durationMs": 3071,
+    "usage": {
+      "prompt": 403,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 468
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1768",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルからうつ病の動物モデルに関する研究であることを示す情報がなく、むしろ血行動態（hemodynamic）に関する研究であり、呼吸性または循環器系の抑制を指している可能性が高い"
+    ],
+    "durationMs": 4501,
+    "usage": {
+      "prompt": 402,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1769",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は遅発型過敏反応（DTH）の抑制を指しており、うつ病モデルではない",
+      "研究はマウスを用いているが、うつ病の in vivo モデルに関するものではない"
+    ],
+    "durationMs": 5192,
+    "usage": {
+      "prompt": 609,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 749
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1770",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルが「Madness」のみで、うつ病の動物モデルに関する情報が全く不明であるため、感度を優先して含める可能性を考慮"
+    ],
+    "durationMs": 4577,
+    "usage": {
+      "prompt": 390,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 490
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1771",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではない",
+      "研究対象は培養脊髄ニューロンであり、in vivoモデルではない",
+      "うつ病ではなく痙攣（convulsant）に関する研究"
+    ],
+    "durationMs": 9292,
+    "usage": {
+      "prompt": 567,
+      "completion": 245,
+      "reasoning": 0,
+      "total": 812
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1772",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "学習性無力感（LH）はうつ病の動物モデルであり、Sprague-Dawleyラットを用いたin vivo研究であるため、対象となる。"
+    ],
+    "durationMs": 5722,
+    "usage": {
+      "prompt": 686,
+      "completion": 159,
+      "reasoning": 0,
+      "total": 845
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1773",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルを用いた研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 7012,
+    "usage": {
+      "prompt": 646,
+      "completion": 199,
+      "reasoning": 0,
+      "total": 845
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1774",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓の抑制（cardiac depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 5060,
+    "usage": {
+      "prompt": 563,
+      "completion": 136,
+      "reasoning": 0,
+      "total": 699
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1775",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、シナプス可塑性の一種である長期抑圧（LTD）を指している"
+    ],
+    "durationMs": 5890,
+    "usage": {
+      "prompt": 538,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 683
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1776",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（強制水泳試験）に関する動物実験であり、ヒト研究ではないため"
+    ],
+    "durationMs": 5718,
+    "usage": {
+      "prompt": 900,
+      "completion": 149,
+      "reasoning": 0,
+      "total": 1049
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1777",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした縦断的研究であり、動物モデルではない"
+    ],
+    "durationMs": 4348,
+    "usage": {
+      "prompt": 677,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 786
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1778",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトであり、動物モデルを用いたうつ病の研究ではない"
+    ],
+    "durationMs": 5168,
+    "usage": {
+      "prompt": 903,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 1040
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1779",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す証拠がない",
+      "抄録がなく、研究内容を判断する材料が不足しているが、タイトルからうつ病の動物モデルとは無関係と判断できる"
+    ],
+    "durationMs": 5014,
+    "usage": {
+      "prompt": 400,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 540
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1780",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」の記載がなく、対象が乳腺組織のin vitro研究であるため、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4697,
+    "usage": {
+      "prompt": 402,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1781",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長抑制（growth depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 3762,
+    "usage": {
+      "prompt": 699,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 795
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1782",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心機能抑制（cardiac depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5295,
+    "usage": {
+      "prompt": 858,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 1002
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1783",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルに関する研究ではなく、小腸運動性に関する研究である"
+    ],
+    "durationMs": 3797,
+    "usage": {
+      "prompt": 597,
+      "completion": 100,
+      "reasoning": 0,
+      "total": 697
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1784",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3711,
+    "usage": {
+      "prompt": 745,
+      "completion": 94,
+      "reasoning": 0,
+      "total": 839
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1785",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は神経活動の抑制（MUAの抑制）を指しており、うつ病モデルではない",
+      "対象はくも膜下出血後の心血管反応に関する動物実験であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4715,
+    "usage": {
+      "prompt": 704,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 835
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1786",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性があり、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 4139,
+    "usage": {
+      "prompt": 420,
+      "completion": 104,
+      "reasoning": 0,
+      "total": 524
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1787",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデルを用いたin vivo研究であり、対象がラットであるため"
+    ],
+    "durationMs": 5024,
+    "usage": {
+      "prompt": 836,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 978
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1788",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病の動物モデル（ECS）に関する研究であり、in vivoの動物実験であるため"
+    ],
+    "durationMs": 4371,
+    "usage": {
+      "prompt": 662,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 782
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1789",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "抄録は人間のうつ病（思春期および成人）に焦点を当てており、in vivo動物モデルに関する記述が明確に含まれていないため、対象外と判断される"
+    ],
+    "durationMs": 4620,
+    "usage": {
+      "prompt": 704,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 832
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1790",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能低下ではなく、長期抑圧（long-term depression, LTD）という神経科学用語として使われており、うつ病モデルではない",
+      "対象はフラジャイルX症候群のマウスモデルであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5560,
+    "usage": {
+      "prompt": 714,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 867
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1791",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4390,
+    "usage": {
+      "prompt": 660,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 780
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1792",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経伝達の抑制（神経生理学的抑制）を指しており、うつ病（depression as a psychiatric disorder）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4490,
+    "usage": {
+      "prompt": 542,
+      "completion": 120,
+      "reasoning": 0,
+      "total": 662
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1793",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性があるが、本抄録では「depression of fatty acid absorption」とあり、これは吸収の抑制を意味しており、うつ病（depression）とは無関係である。また、うつ病の動物モデルに関する研究ではない。"
+    ],
+    "durationMs": 5424,
+    "usage": {
+      "prompt": 746,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 890
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1794",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（ventilatory depression）を指しており、うつ病モデルではないため"
+    ],
+    "durationMs": 5053,
+    "usage": {
+      "prompt": 789,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 930
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1795",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関するin vivo動物実験であり、人間の研究ではない"
+    ],
+    "durationMs": 5980,
+    "usage": {
+      "prompt": 619,
+      "completion": 158,
+      "reasoning": 0,
+      "total": 777
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1796",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が不安行動（anxiety）に焦点を当てており、うつ病（depression）のin vivoモデルではない"
+    ],
+    "durationMs": 5557,
+    "usage": {
+      "prompt": 722,
+      "completion": 155,
+      "reasoning": 0,
+      "total": 877
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1797",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や心臓の機能低下（洞節自律性および心房内伝導の抑制）を指しており、うつ病モデルではないため"
+    ],
+    "durationMs": 4905,
+    "usage": {
+      "prompt": 619,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 743
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1798",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "in vivo動物モデル（ラットおよびマウス）を用いたうつ病研究であり、対象とする動物実験に該当する"
+    ],
+    "durationMs": 6725,
+    "usage": {
+      "prompt": 1217,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 1393
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1799",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "タイトルに「animal models of depression」と明記されており、うつ病のin vivo動物モデルに関する研究であると明確に判断できる。"
+    ],
+    "durationMs": 4249,
+    "usage": {
+      "prompt": 407,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 508
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1800",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」とあるが、動物実験かどうか不明であり、抄録が存在しないため判断できない。感度を重視し、包括を検討する必要がある。"
+    ],
+    "durationMs": 4379,
+    "usage": {
+      "prompt": 404,
+      "completion": 112,
+      "reasoning": 0,
+      "total": 516
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1801",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は気分障害としてのうつ病ではなく、cAMPレベルの「低下（depression）」を指しており、対象は動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 4407,
+    "usage": {
+      "prompt": 618,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 739
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1802",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や神経抑制など、うつ病とは無関係な文脈で使用されている",
+      "研究は麻酔の局所効果を評価するものであり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5784,
+    "usage": {
+      "prompt": 1002,
+      "completion": 154,
+      "reasoning": 0,
+      "total": 1156
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1803",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3854,
+    "usage": {
+      "prompt": 947,
+      "completion": 91,
+      "reasoning": 0,
+      "total": 1038
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1804",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病様行動を評価する動物実験（BACHDマウスモデル）を対象としており、in vivoのうつ病モデルに関する研究である"
+    ],
+    "durationMs": 7135,
+    "usage": {
+      "prompt": 820,
+      "completion": 193,
+      "reasoning": 0,
+      "total": 1013
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1805",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が肝機能の抑制を指しており、うつ病モデルではない",
+      "in vivo うつ病モデルに関する研究ではない"
+    ],
+    "durationMs": 4283,
+    "usage": {
+      "prompt": 619,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 734
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1806",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、内リンパDC電位に関する研究であり、うつ病のin vivo動物モデルの研究ではないと判断される"
+    ],
+    "durationMs": 2758,
+    "usage": {
+      "prompt": 402,
+      "completion": 65,
+      "reasoning": 0,
+      "total": 467
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1807",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病の動物モデルに関する研究であり、in vivo動物研究であるため"
+    ],
+    "durationMs": 6075,
+    "usage": {
+      "prompt": 678,
+      "completion": 166,
+      "reasoning": 0,
+      "total": 844
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1808",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトまたはラットの組織を用いたin vitro酵素選択性評価であり、うつ病のin vivo動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 4570,
+    "usage": {
+      "prompt": 746,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 873
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1809",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫反応の抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 3890,
+    "usage": {
+      "prompt": 430,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 523
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1810",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "in vitro 細胞実験（ラットC6グリオーマ細胞）であり、in vivo モデルではない"
+    ],
+    "durationMs": 4293,
+    "usage": {
+      "prompt": 758,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 863
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1811",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、拡張性抑制（spreading depression）を指しており、これは神経生理学的現象でありうつ病モデルではない"
+    ],
+    "durationMs": 5766,
+    "usage": {
+      "prompt": 632,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 776
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1812",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が気道平滑筋の収縮であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5335,
+    "usage": {
+      "prompt": 775,
+      "completion": 143,
+      "reasoning": 0,
+      "total": 918
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1813",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はうつ病ではなく、ヨウ化物取り込みの抑制（生理学的抑制）を指している",
+      "in vivo うつ病モデルの動物研究ではなく、ラット由来の甲状腺細胞株（in vitro）を用いた研究"
+    ],
+    "durationMs": 7310,
+    "usage": {
+      "prompt": 658,
+      "completion": 212,
+      "reasoning": 0,
+      "total": 870
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1814",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "抄録に「recent animal and laboratory studies」とあるが、本研究自体が動物実験かどうかは不明であり、人間を対象とした臨床試験のメタアナリシスである可能性が高い。感度を優先し、フルテキスト確認が必要なため仮に含める可能性を考慮。"
+    ],
+    "durationMs": 5239,
+    "usage": {
+      "prompt": 594,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 742
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1815",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「treatment resistant depression」とあるが、これはヒトを対象としたうつ病治療に関するものであり、in vivo動物モデルの研究ではない。"
+    ],
+    "durationMs": 3902,
+    "usage": {
+      "prompt": 408,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 513
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1816",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした臨床研究であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 4147,
+    "usage": {
+      "prompt": 545,
+      "completion": 98,
+      "reasoning": 0,
+      "total": 643
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1817",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象はうつ病モデルではなく、てんかんモデル（GEPR-9ラット）であり、うつ病に関する記述がない。"
+    ],
+    "durationMs": 4158,
+    "usage": {
+      "prompt": 769,
+      "completion": 106,
+      "reasoning": 0,
+      "total": 875
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1818",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は脂質吸収の低下を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3705,
+    "usage": {
+      "prompt": 595,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 692
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1819",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「immune depression（免疫抑制）」を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4065,
+    "usage": {
+      "prompt": 793,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 894
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1820",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト以外の動物（犬）であるが、うつ病モデルではなく、出血およびアルコールによる循環応答を調べた研究であり、精神疾患としてのうつ病とは無関係である"
+    ],
+    "durationMs": 4731,
+    "usage": {
+      "prompt": 399,
+      "completion": 127,
+      "reasoning": 0,
+      "total": 526
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1821",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、カエル膀胱の受容体における解糖系の抑制に関する生理学的研究である"
+    ],
+    "durationMs": 5810,
+    "usage": {
+      "prompt": 514,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 684
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1822",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がマウス（BALB/c）を用いたうつ病様行動のin vivo動物実験であり、人間を対象とした研究ではない"
+    ],
+    "durationMs": 5158,
+    "usage": {
+      "prompt": 770,
+      "completion": 138,
+      "reasoning": 0,
+      "total": 908
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1823",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラット（in vivo動物モデル）であり、うつ病の症状（快感欠如）を評価しているため"
+    ],
+    "durationMs": 5749,
+    "usage": {
+      "prompt": 697,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 861
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1824",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は皮膚の免疫機能の抑制を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 6983,
+    "usage": {
+      "prompt": 704,
+      "completion": 205,
+      "reasoning": 0,
+      "total": 909
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1825",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデルに関するin vivo動物実験であり、ヒト研究ではなく、呼吸・循環器系の抑制を意味する「depression」ではない"
+    ],
+    "durationMs": 5856,
+    "usage": {
+      "prompt": 857,
+      "completion": 152,
+      "reasoning": 0,
+      "total": 1009
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1826",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（強制泳泳試験）に関する動物実験であり、対象とするin vivoモデルの研究である"
+    ],
+    "durationMs": 6539,
+    "usage": {
+      "prompt": 762,
+      "completion": 178,
+      "reasoning": 0,
+      "total": 940
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1827",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウス脳由来のシナプトソームを用いたin vivo由来の実験であり、うつ病治療薬の作用機序に関する動物モデル研究である"
+    ],
+    "durationMs": 5188,
+    "usage": {
+      "prompt": 827,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 967
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1828",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5569,
+    "usage": {
+      "prompt": 926,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 1083
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1829",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（強制泳泳試験および尾吊り試験）に関する動物実験であり、対象とするin vivoうつ病モデルの研究に該当する"
+    ],
+    "durationMs": 7406,
+    "usage": {
+      "prompt": 853,
+      "completion": 183,
+      "reasoning": 0,
+      "total": 1036
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1830",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の用語が含まれておらず、不妊効果に関する研究であるため"
+    ],
+    "durationMs": 2600,
+    "usage": {
+      "prompt": 413,
+      "completion": 59,
+      "reasoning": 0,
+      "total": 472
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1831",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が昆虫（テントウムシ）の行動に関する研究であり、うつ病のin vivoモデルを用いた動物研究ではない。また、「depression（抑制）」が「inbreeding depression（近交弱勢）」という遺伝学的文脈で使用されており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5252,
+    "usage": {
+      "prompt": 662,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 813
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1832",
+    "label_included": 1,
+    "include_probability": 0.7,
+    "reasons": [
+      "タイトルに「ストレス誘発性行動障害」とあり、うつ病の動物モデルに関連する可能性があるが、抄録がなく詳細が不明なため不確実"
+    ],
+    "durationMs": 4552,
+    "usage": {
+      "prompt": 406,
+      "completion": 108,
+      "reasoning": 0,
+      "total": 514
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1833",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depress」は「抑制」を意味しており、うつ病（depression）の動物モデルに関する研究ではない。呼吸性または心臓の抑制などではなく、神経伝達の抑制を扱っているが、うつ病モデルではない。"
+    ],
+    "durationMs": 4946,
+    "usage": {
+      "prompt": 908,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 1036
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1834",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、四塩化炭素による肝ミトコンドリア酵素活性の変化を調べた動物実験である。うつ病とは無関係。"
+    ],
+    "durationMs": 3241,
+    "usage": {
+      "prompt": 762,
+      "completion": 76,
+      "reasoning": 0,
+      "total": 838
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1835",
+    "label_included": 0,
+    "include_probability": 0.5,
+    "reasons": [
+      "抄録に「depression」とあるが、動物モデルを用いた研究かどうかが明記されていないため、全文確認が必要"
+    ],
+    "durationMs": 3884,
+    "usage": {
+      "prompt": 641,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 742
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1836",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、拡張性抑制（spreading depression）という神経生理学的現象を指している",
+      "呼吸性・心臓性の抑制ではなく脳内の電気生理学的現象に関する研究であり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 6828,
+    "usage": {
+      "prompt": 815,
+      "completion": 198,
+      "reasoning": 0,
+      "total": 1013
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1837",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がマウス胚細胞を用いた in vitro 細胞培養実験であり、in vivo うつ病モデルではない"
+    ],
+    "durationMs": 4139,
+    "usage": {
+      "prompt": 711,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 818
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1838",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「inbreeding depression（近交劣勢）」を指しており、精神疾患としてのうつ病の動物モデルではない"
+    ],
+    "durationMs": 4139,
+    "usage": {
+      "prompt": 798,
+      "completion": 105,
+      "reasoning": 0,
+      "total": 903
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1839",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトではなく犬であるが、うつ病（depression）ではなく心筋機能低下（myocardial dysfunction）を指しており、精神疾患としてのうつ病の動物モデルではない"
+    ],
+    "durationMs": 5612,
+    "usage": {
+      "prompt": 894,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 1054
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1840",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivoマウスを用いたうつ病モデル（強制泳泳試験）に関する動物実験であり、対象とするうつ病は精神疾患としてのうつであり、呼吸抑制や心機能抑制などの「depression」とは無関係である"
+    ],
+    "durationMs": 6379,
+    "usage": {
+      "prompt": 590,
+      "completion": 187,
+      "reasoning": 0,
+      "total": 777
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1841",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が成長パフォーマンスの低下を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4069,
+    "usage": {
+      "prompt": 721,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 822
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1842",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が循環器系の抑制（circulatory depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4637,
+    "usage": {
+      "prompt": 883,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 1005
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1843",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢神経系の抑制（麻酔による機能低下）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5410,
+    "usage": {
+      "prompt": 737,
+      "completion": 151,
+      "reasoning": 0,
+      "total": 888
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1844",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルを用いた研究であり、対象となる動物実験が明確に記載されている"
+    ],
+    "durationMs": 6623,
+    "usage": {
+      "prompt": 707,
+      "completion": 171,
+      "reasoning": 0,
+      "total": 878
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1845",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデルを対象とした研究であり、うつ病（affective disorders）に関連する神経化学的変化を調べている。対象はマウスであり、ヒト研究ではない。"
+    ],
+    "durationMs": 7116,
+    "usage": {
+      "prompt": 763,
+      "completion": 207,
+      "reasoning": 0,
+      "total": 970
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1846",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラットであるものの、うつ病のin vivoモデルに関する研究ではなく、運動活動と概日リズムに焦点を当てており、うつ病の評価やモデル化は行われていない。抄録中で「depression」は疾患としてのうつ病ではなく活動量の低下（nonsignificantly depressed）や参考文献としての人間の躁うつ病に言及しているのみであり、本研究自体はうつ病モデルではない。"
+    ],
+    "durationMs": 8301,
+    "usage": {
+      "prompt": 752,
+      "completion": 246,
+      "reasoning": 0,
+      "total": 998
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1847",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病のin vivo動物モデル（ヒヨコ）を用いた研究であり、ヒト研究ではない。うつ病は呼吸抑制や心機能抑制ではなく、行動的絶望やストレス脆弱性に基づく精神疾患モデルとして扱われている。"
+    ],
+    "durationMs": 6983,
+    "usage": {
+      "prompt": 697,
+      "completion": 190,
+      "reasoning": 0,
+      "total": 887
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1848",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸器や循環器系の機能低下（心筋抑制）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 3810,
+    "usage": {
+      "prompt": 401,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 503
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1849",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、急性高血糖時の脳血流量の変化を調べた動物実験である"
+    ],
+    "durationMs": 4527,
+    "usage": {
+      "prompt": 572,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 691
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1850",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivoモデルではなく、高齢マウスの造血幹細胞に関する研究である"
+    ],
+    "durationMs": 6398,
+    "usage": {
+      "prompt": 607,
+      "completion": 186,
+      "reasoning": 0,
+      "total": 793
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1851",
+    "label_included": 0,
+    "include_probability": 0.3,
+    "reasons": [
+      "「LPS-induced depression of general activity」とあるが、これは一般的な活動低下を指しており、うつ病モデルではない可能性が高い。うつ病（depression）の動物モデルに関する研究とは明確に判断できない。"
+    ],
+    "durationMs": 4553,
+    "usage": {
+      "prompt": 614,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 737
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1852",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない。タイトルから抗エストロゲン化合物によるラットの着床遅延に関する研究と推測され、うつ病とは無関係である。"
+    ],
+    "durationMs": 4560,
+    "usage": {
+      "prompt": 400,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 517
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1853",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語は呼吸抑制や心機能抑制ではなく、シナプス伝達の長期抑圧（LTD）を指しており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4404,
+    "usage": {
+      "prompt": 772,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 891
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1854",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではないため除外される"
+    ],
+    "durationMs": 4792,
+    "usage": {
+      "prompt": 758,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 889
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1855",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓抑制（cardiac depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4586,
+    "usage": {
+      "prompt": 772,
+      "completion": 124,
+      "reasoning": 0,
+      "total": 896
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1856",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がin vivoモデルのうつ病研究ではなく、ヒトまたはin vitro（海馬スライス）を用いた神経生理学的研究である"
+    ],
+    "durationMs": 4815,
+    "usage": {
+      "prompt": 509,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 632
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1857",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「depression」や「うつ」に関する言及がなく、抄録がないため動物モデルのうつ病研究かどうか判断できない"
+    ],
+    "durationMs": 2501,
+    "usage": {
+      "prompt": 398,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 455
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1858",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない"
+    ],
+    "durationMs": 3589,
+    "usage": {
+      "prompt": 405,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1859",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病のin vivo動物モデルではなく、培養神経細胞およびヒト神経芽腫細胞株を用いたin vitro実験である"
+    ],
+    "durationMs": 6517,
+    "usage": {
+      "prompt": 788,
+      "completion": 179,
+      "reasoning": 0,
+      "total": 967
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1860",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 3675,
+    "usage": {
+      "prompt": 686,
+      "completion": 94,
+      "reasoning": 0,
+      "total": 780
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1861",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がうつ病の動物モデルではなく、不安様行動を調べた研究である"
+    ],
+    "durationMs": 4991,
+    "usage": {
+      "prompt": 611,
+      "completion": 139,
+      "reasoning": 0,
+      "total": 750
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1862",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく「cortical spreading depression（皮質拡延性抑制）」を指しており、うつ病モデルではないため"
+    ],
+    "durationMs": 5666,
+    "usage": {
+      "prompt": 678,
+      "completion": 160,
+      "reasoning": 0,
+      "total": 838
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1863",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「locomotor depression」は運動抑制を指しており、うつ病（depression）の動物モデルではない。対象はドパミン機能の操作による運動変化に関する研究であり、うつ病のin vivoモデルではない。"
+    ],
+    "durationMs": 4780,
+    "usage": {
+      "prompt": 724,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1864",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、ラット海馬のin vitro電気生理学的研究である"
+    ],
+    "durationMs": 5496,
+    "usage": {
+      "prompt": 900,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 1037
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1865",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2357,
+    "usage": {
+      "prompt": 405,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 456
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1866",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」または「うつ病」に関する記載がなく、リビドー抑制剤に関する研究であり、うつ病のin vivoモデルを対象としていないと判断される"
+    ],
+    "durationMs": 2787,
+    "usage": {
+      "prompt": 410,
+      "completion": 70,
+      "reasoning": 0,
+      "total": 480
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1867",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4783,
+    "usage": {
+      "prompt": 596,
+      "completion": 103,
+      "reasoning": 0,
+      "total": 699
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1868",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "in vivo動物モデル（マウス）を用いたうつ病行動モデルの研究であり、明確に動物実験である"
+    ],
+    "durationMs": 6851,
+    "usage": {
+      "prompt": 1010,
+      "completion": 165,
+      "reasoning": 0,
+      "total": 1175
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1869",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録からうつ病の動物モデルに関する記述が見当たらず、主題が胆汁排泄に関する生体外または薬物代謝研究と推測されるため"
+    ],
+    "durationMs": 2914,
+    "usage": {
+      "prompt": 416,
+      "completion": 68,
+      "reasoning": 0,
+      "total": 484
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1870",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動の動物モデルに関する研究であり、in vivo のうつ病モデルに該当する"
+    ],
+    "durationMs": 5311,
+    "usage": {
+      "prompt": 712,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 865
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1871",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制と同様に、胆汁流量の「低下」を意味しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5626,
+    "usage": {
+      "prompt": 651,
+      "completion": 163,
+      "reasoning": 0,
+      "total": 814
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1872",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はT細胞レベルの低下を指しており、うつ病モデルではない",
+      "研究は免疫細胞への影響を調べるもので、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4352,
+    "usage": {
+      "prompt": 539,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 654
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1873",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や循環抑制など生理機能の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 6957,
+    "usage": {
+      "prompt": 666,
+      "completion": 195,
+      "reasoning": 0,
+      "total": 861
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1874",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（ventilatory depression）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5321,
+    "usage": {
+      "prompt": 648,
+      "completion": 147,
+      "reasoning": 0,
+      "total": 795
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1875",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がC2C12筋芽細胞を用いたin vitro実験であり、うつ病のin vivo動物モデルではない",
+      "「depression（抑うつ）」という用語が一切使用されておらず、研究対象は筋細胞の分化である"
+    ],
+    "durationMs": 3601,
+    "usage": {
+      "prompt": 757,
+      "completion": 93,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1876",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が腫瘍細胞および細胞外酵素系であり、うつ病のin vivo動物モデルを用いた研究ではない"
+    ],
+    "durationMs": 6116,
+    "usage": {
+      "prompt": 585,
+      "completion": 174,
+      "reasoning": 0,
+      "total": 759
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1877",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経細胞の自発的発火の抑制（生理学的抑制）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4208,
+    "usage": {
+      "prompt": 543,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 658
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1878",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は自然殺傷細胞の腫瘍細胞殺傷活性の抑制を指しており、うつ病モデルではない",
+      "研究はin vitro実験であり、in vivoうつ病モデルではない"
+    ],
+    "durationMs": 4475,
+    "usage": {
+      "prompt": 513,
+      "completion": 125,
+      "reasoning": 0,
+      "total": 638
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1879",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、線維筋痛症様疼痛モデルを対象としており、うつ病様行動は観察されなかったと明記されている"
+    ],
+    "durationMs": 5029,
+    "usage": {
+      "prompt": 679,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 808
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1880",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトの双極性障害（躁うつ病）治療に関する言及はあるが、うつ病のin vivo動物モデルを対象とした研究ではない",
+      "研究対象は酵素の構造・進化に関する生化学的分析であり、動物モデルを用いたうつ病研究ではない"
+    ],
+    "durationMs": 5604,
+    "usage": {
+      "prompt": 809,
+      "completion": 157,
+      "reasoning": 0,
+      "total": 966
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1881",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病様行動（強制水泳試験およびオープンフィールド試験で評価）に関するin vivo動物実験であり、対象がヒトでなく、呼吸抑制などの「depression」とは無関係である"
+    ],
+    "durationMs": 7245,
+    "usage": {
+      "prompt": 790,
+      "completion": 210,
+      "reasoning": 0,
+      "total": 1000
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1882",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2248,
+    "usage": {
+      "prompt": 401,
+      "completion": 51,
+      "reasoning": 0,
+      "total": 452
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1883",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ様行動のin vivo研究であり、ヒト研究や呼吸・心臓の抑制とは無関係である"
+    ],
+    "durationMs": 5354,
+    "usage": {
+      "prompt": 808,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 958
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1884",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患が肺線維症であり、うつ病（depression）の動物モデルに関する研究ではない",
+      "「depression」が呼吸抑制などを指す文脈ではなく、そもそも「depression」という語が出現していない"
+    ],
+    "durationMs": 3364,
+    "usage": {
+      "prompt": 597,
+      "completion": 80,
+      "reasoning": 0,
+      "total": 677
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1885",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、胎児の心筋抑制（myocardial depression）を指している",
+      "対象は羊を用いた麻酔の生理影響に関する研究であり、うつ病の動物モデルではない"
+    ],
+    "durationMs": 5241,
+    "usage": {
+      "prompt": 797,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 923
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1886",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、カエルの繁殖行動に関する研究である"
+    ],
+    "durationMs": 4462,
+    "usage": {
+      "prompt": 422,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 536
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1887",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が植物（Mimulus guttatus）と昆虫（spittlebug）の相互作用に関する研究であり、うつ病のin vivo動物モデルを対象としていない"
+    ],
+    "durationMs": 4842,
+    "usage": {
+      "prompt": 757,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 888
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1888",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルにおける電気けいれん刺激（ECS）の影響についての動物実験が含まれている",
+      "「depression」が精神疾患としてのうつ病を指しており、呼吸抑制などの他の意味ではない"
+    ],
+    "durationMs": 8046,
+    "usage": {
+      "prompt": 1125,
+      "completion": 225,
+      "reasoning": 0,
+      "total": 1350
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1889",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象疾患が壊死性腸炎（necrotizing enterocolitis）であり、うつ病（depression）の動物モデルではない",
+      "「depression」が本抄録中に一切出現しないうえ、呼吸抑制や心機能抑制などの他の意味での「depression」にも言及されていない"
+    ],
+    "durationMs": 3857,
+    "usage": {
+      "prompt": 749,
+      "completion": 101,
+      "reasoning": 0,
+      "total": 850
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1890",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "対象がラットを用いたうつ病の動物モデルに関する研究であり、ヒト研究ではなく、呼吸抑制などの他の意味での「depression」ではない"
+    ],
+    "durationMs": 7547,
+    "usage": {
+      "prompt": 859,
+      "completion": 222,
+      "reasoning": 0,
+      "total": 1081
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1891",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデルに関する研究であり、in vivo研究であるため"
+    ],
+    "durationMs": 6007,
+    "usage": {
+      "prompt": 495,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 670
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1892",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という語が呼吸抑制や心機能抑制などを指しており、うつ病モデルではないと明確に判断できる",
+      "研究対象はラットの肝臓細胞のAh受容体であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4701,
+    "usage": {
+      "prompt": 638,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 769
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1893",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "マウス（C57BL/6J）を用いたin vivoうつ病モデルの研究であり、強制水泳試験（FST）で抗うつ様行動を評価している。対象が動物であり、呼吸抑制や心機能低下などの「depression」ではない。"
+    ],
+    "durationMs": 6790,
+    "usage": {
+      "prompt": 857,
+      "completion": 198,
+      "reasoning": 0,
+      "total": 1055
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1894",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから、研究はマウスにおける抗生物質耐性の細菌間伝達に関するものであり、うつ病の動物モデルに関する研究ではないと判断される。"
+    ],
+    "durationMs": 4474,
+    "usage": {
+      "prompt": 405,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 519
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1895",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がシナプス伝導の長期抑制（long-term depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 4368,
+    "usage": {
+      "prompt": 651,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 768
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1896",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気分障害としてのうつ病ではなく、熱処理後の「lymphoid activity」の一時的低下（抑制）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4583,
+    "usage": {
+      "prompt": 744,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 872
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1897",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病関連の記載がなく、マウスの乳腺腫瘍に関する研究であり、うつ病のin vivoモデルを対象としていない"
+    ],
+    "durationMs": 4862,
+    "usage": {
+      "prompt": 400,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 521
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1898",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される",
+      "ヒトおよびウシを対象とした生体外（in vitro）研究の可能性が高く、in vivoうつ病モデルの研究ではない"
+    ],
+    "durationMs": 5625,
+    "usage": {
+      "prompt": 405,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 545
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1899",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、マイコプラズマ感染症に対する抗生物質の効果を調べた動物実験である"
+    ],
+    "durationMs": 4548,
+    "usage": {
+      "prompt": 682,
+      "completion": 117,
+      "reasoning": 0,
+      "total": 799
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1900",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "うつ病の動物モデル（先天性学習性無力症ラット）を用いた研究であり、in vivo動物実験である"
+    ],
+    "durationMs": 8458,
+    "usage": {
+      "prompt": 535,
+      "completion": 243,
+      "reasoning": 0,
+      "total": 778
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1901",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制（respiratory depression）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 3958,
+    "usage": {
+      "prompt": 698,
+      "completion": 96,
+      "reasoning": 0,
+      "total": 794
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1902",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、長期増強（LTP）とグルタミン酸放出のメカニズムに関する神経生理学的研究である"
+    ],
+    "durationMs": 5094,
+    "usage": {
+      "prompt": 801,
+      "completion": 140,
+      "reasoning": 0,
+      "total": 941
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1903",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、欠伸てんかんの動物モデル（WAG/Rijラット）を用いたT型カルシウムチャネルの研究である"
+    ],
+    "durationMs": 4658,
+    "usage": {
+      "prompt": 680,
+      "completion": 129,
+      "reasoning": 0,
+      "total": 809
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1904",
+    "label_included": 1,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「うつ病」や動物モデルに関する記述がなく、ACTH分泌に関する研究であるため、うつ病のin vivoモデルとは関連性が低いと判断される"
+    ],
+    "durationMs": 4588,
+    "usage": {
+      "prompt": 403,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 519
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1905",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が「cardiac depression（心筋抑制）」を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4603,
+    "usage": {
+      "prompt": 826,
+      "completion": 113,
+      "reasoning": 0,
+      "total": 939
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1906",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「うつ病」や動物モデルに関する記述がなく、抄録も存在しないため、対象外と判断される"
+    ],
+    "durationMs": 2828,
+    "usage": {
+      "prompt": 405,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 462
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1907",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、長期抑圧（long-term depression, LTD）という神経生理学的現象を指している",
+      "対象はラットであるが、うつ病モデルではなくメスアンフェタミンによる認知機能障害モデル",
+      "うつ病（depression）のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 8715,
+    "usage": {
+      "prompt": 684,
+      "completion": 220,
+      "reasoning": 0,
+      "total": 904
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1908",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は呼吸抑制や循環抑制などを指しており、うつ病モデルではない",
+      "研究対象は肝臓保存であり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 4520,
+    "usage": {
+      "prompt": 910,
+      "completion": 114,
+      "reasoning": 0,
+      "total": 1024
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1909",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルではない"
+    ],
+    "durationMs": 4952,
+    "usage": {
+      "prompt": 889,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 1010
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1910",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がラット心室筋細胞であり、うつ病のin vivoモデルではない。また、「depression」はこの文脈で心機能の抑制（cardiac depression）を指しており、うつ病とは無関係である。"
+    ],
+    "durationMs": 6537,
+    "usage": {
+      "prompt": 833,
+      "completion": 190,
+      "reasoning": 0,
+      "total": 1023
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1911",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "「depression」が含まれておらず、対象が骨格筋のタンパク質分解である"
+    ],
+    "durationMs": 2959,
+    "usage": {
+      "prompt": 414,
+      "completion": 60,
+      "reasoning": 0,
+      "total": 474
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1912",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」がうつ病ではなく、心筋抑制（myocardial depression）を指しており、精神疾患モデルではない"
+    ],
+    "durationMs": 5123,
+    "usage": {
+      "prompt": 877,
+      "completion": 145,
+      "reasoning": 0,
+      "total": 1022
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1913",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」はシナプスの機能的抑制（synaptic depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4758,
+    "usage": {
+      "prompt": 750,
+      "completion": 133,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1914",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「うつ病」や「depression」の明確な記載がなく、代償性副腎肥大に関する研究であり、うつ病のin vivoモデルを対象としているかどうか不明である"
+    ],
+    "durationMs": 3838,
+    "usage": {
+      "prompt": 408,
+      "completion": 74,
+      "reasoning": 0,
+      "total": 482
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1915",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録に「うつ病」または「depression」の言及がなく、研究対象がin vivoうつ病モデルである可能性が極めて低い"
+    ],
+    "durationMs": 3306,
+    "usage": {
+      "prompt": 421,
+      "completion": 64,
+      "reasoning": 0,
+      "total": 485
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1916",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "慢性ストレスによるうつ病モデルを用いたラットのin vivo研究であり、対象が動物であり、臨床的うつ病に関連している"
+    ],
+    "durationMs": 6110,
+    "usage": {
+      "prompt": 650,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 814
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1917",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）やその動物モデルに関する記述がなく、肝臓のステロール合成や酵素活性に関する研究であるため"
+    ],
+    "durationMs": 3193,
+    "usage": {
+      "prompt": 429,
+      "completion": 68,
+      "reasoning": 0,
+      "total": 497
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1918",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、マンガン摂取が母体および胎児のミネラル濃度に与える影響を調べた研究である"
+    ],
+    "durationMs": 2930,
+    "usage": {
+      "prompt": 715,
+      "completion": 67,
+      "reasoning": 0,
+      "total": 782
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1919",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心機能抑制ではなく眼圧低下（ocular depression）を指しており、うつ病モデルの動物研究ではない"
+    ],
+    "durationMs": 5062,
+    "usage": {
+      "prompt": 651,
+      "completion": 116,
+      "reasoning": 0,
+      "total": 767
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1920",
+    "label_included": 0,
+    "include_probability": 0.2,
+    "reasons": [
+      "「depressive effect on the central nervous system」とあるが、これは抗うつ作用ではなく中枢神経抑制を指しており、うつ病のin vivoモデルに関する研究ではない可能性が高い。動物実験か人間研究かの記載がなく、うつ病モデルの使用も明記されていない。"
+    ],
+    "durationMs": 5388,
+    "usage": {
+      "prompt": 778,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 924
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1921",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は免疫細胞の機能低下（例：splenocytesの応答低下）を指しており、うつ病モデルではない",
+      "研究は炎症応答に焦点を当てており、うつ病のin vivoモデルに関するものではない"
+    ],
+    "durationMs": 6521,
+    "usage": {
+      "prompt": 612,
+      "completion": 187,
+      "reasoning": 0,
+      "total": 799
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1922",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」やうつ病に関連する用語が含まれておらず、動物モデルを用いたうつ病研究であることを示す根拠がない"
+    ],
+    "durationMs": 2919,
+    "usage": {
+      "prompt": 417,
+      "completion": 67,
+      "reasoning": 0,
+      "total": 484
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1923",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経学的抑圧（neurologic depression）として使われており、うつ病モデルの動物実験ではない"
+    ],
+    "durationMs": 4084,
+    "usage": {
+      "prompt": 756,
+      "completion": 107,
+      "reasoning": 0,
+      "total": 863
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1924",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がブタの畜産管理に関する研究であり、うつ病のin vivo動物モデルを用いた研究ではない。「depression」は平均日増体（ADG）の低下を指しており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 5067,
+    "usage": {
+      "prompt": 749,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 883
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1925",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラットであるが、うつ病モデルではなく、ストレス下でのHPA軸の調節に関する研究であり、うつ病のin vivoモデルを用いていない"
+    ],
+    "durationMs": 5583,
+    "usage": {
+      "prompt": 757,
+      "completion": 148,
+      "reasoning": 0,
+      "total": 905
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1926",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivo動物モデルに関する研究ではなく、睡眠調節に関連する神経細胞の分子プロファイリングを目的とした研究である。うつ病は傍証的に言及されているのみで、主要な研究対象ではない。"
+    ],
+    "durationMs": 5108,
+    "usage": {
+      "prompt": 692,
+      "completion": 137,
+      "reasoning": 0,
+      "total": 829
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1927",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、感覚皮質の神経回路発達に関する研究である"
+    ],
+    "durationMs": 2434,
+    "usage": {
+      "prompt": 881,
+      "completion": 55,
+      "reasoning": 0,
+      "total": 936
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1928",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語がうつ病ではなく、一般的な抑うつ状態や活動低下を指している可能性が高い",
+      "研究対象はウサギの胃閉塞であり、うつ病のin vivoモデルではない",
+      "対象疾患が消化器系の疾患であり、精神疾患ではない"
+    ],
+    "durationMs": 5442,
+    "usage": {
+      "prompt": 521,
+      "completion": 153,
+      "reasoning": 0,
+      "total": 674
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1929",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸性や心臓性の抑制ではなくうつ病を指しているか明確でないが、文脈から免疫機能の「抑制（depression）」を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5150,
+    "usage": {
+      "prompt": 771,
+      "completion": 144,
+      "reasoning": 0,
+      "total": 915
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1930",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される",
+      "胃液分泌の抑制に関する研究であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 2988,
+    "usage": {
+      "prompt": 403,
+      "completion": 72,
+      "reasoning": 0,
+      "total": 475
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1931",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がサケ（Oncorhynchus kisutch）であり、うつ病のin vivoモデルに関する研究ではない。うつ病（depression）という用語は本抄録では「insulin titersを低下させる（depressed plasma insulin titers）」という代謝的文脈で使用されており、精神疾患としてのうつ病とは無関係である。"
+    ],
+    "durationMs": 6205,
+    "usage": {
+      "prompt": 801,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 973
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1932",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 3133,
+    "usage": {
+      "prompt": 401,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 454
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1933",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がXenopus oocytes（カエルの卵母細胞）であり、うつ病のin vivo動物モデルではない",
+      "「depression」という用語が電流の抑制（生理学的抑制）を指しており、うつ病を意味しない"
+    ],
+    "durationMs": 6426,
+    "usage": {
+      "prompt": 826,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 1001
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1934",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "抄録に動物実験やin vivoモデルに関する記述がなく、ヒト研究かin vitro研究の可能性が高い",
+      "「depressive disorders」への言及はあるが、それが動物モデルでの評価を指しているとは明記されていない"
+    ],
+    "durationMs": 5157,
+    "usage": {
+      "prompt": 790,
+      "completion": 128,
+      "reasoning": 0,
+      "total": 918
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1935",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的現象（シナプス抑制）を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 6467,
+    "usage": {
+      "prompt": 579,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 725
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1936",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸系の抑制（気道平滑筋への迷走神経運動経路の抑制）を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 5838,
+    "usage": {
+      "prompt": 638,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 802
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1937",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、ギニアピッグの大腸平滑筋におけるアデノシン三リン酸の弛緩作用を調べた研究である"
+    ],
+    "durationMs": 4464,
+    "usage": {
+      "prompt": 415,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 538
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1938",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒトおよびモルモットの胚・舌の形態学的研究であり、うつ病の動物モデルに関する研究ではない",
+      "抄録中に「depression（うつ病）」という用語は含まれておらず、呼吸抑制や心機能抑制などの他の意味での「depression」も言及されていない"
+    ],
+    "durationMs": 9751,
+    "usage": {
+      "prompt": 575,
+      "completion": 198,
+      "reasoning": 0,
+      "total": 773
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1939",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究ではないと判断される"
+    ],
+    "durationMs": 3019,
+    "usage": {
+      "prompt": 399,
+      "completion": 53,
+      "reasoning": 0,
+      "total": 452
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1940",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "嗅球摘出（OBX）ラットを用いたうつ病の動物モデルに関する研究であり、in vivo の動物実験である"
+    ],
+    "durationMs": 6045,
+    "usage": {
+      "prompt": 860,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 981
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1941",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する研究であり、NPYの抗うつ作用に基づきうつ行動の低下を評価している"
+    ],
+    "durationMs": 4575,
+    "usage": {
+      "prompt": 713,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 839
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1942",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」の語が含まれておらず、うつ病の動物モデルに関する研究である可能性が極めて低い"
+    ],
+    "durationMs": 2325,
+    "usage": {
+      "prompt": 422,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 479
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1943",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではない",
+      "タイトルに「depression」の語が含まれておらず、研究対象が鶏の卵管である"
+    ],
+    "durationMs": 3093,
+    "usage": {
+      "prompt": 409,
+      "completion": 66,
+      "reasoning": 0,
+      "total": 475
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1944",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や血管収縮抑制など生理学的抑制を指しており、うつ病モデルではない",
+      "対象は高血圧ラットであり、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 6677,
+    "usage": {
+      "prompt": 695,
+      "completion": 187,
+      "reasoning": 0,
+      "total": 882
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1945",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット脳スライスを用いたin vitro実験であり、in vivoモデルのうつ病研究ではない",
+      "「depression」はシナプス伝達の抑制（EPSC depression）を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 6424,
+    "usage": {
+      "prompt": 807,
+      "completion": 181,
+      "reasoning": 0,
+      "total": 988
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1946",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病の動物モデル（学習性無力感テスト）が含まれており、対象がヒトでないことが明確であるため"
+    ],
+    "durationMs": 6446,
+    "usage": {
+      "prompt": 777,
+      "completion": 176,
+      "reasoning": 0,
+      "total": 953
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1947",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラビットの肝臓における薬物代謝のin vitro研究であり、うつ病のin vivo動物モデルに関する研究ではない"
+    ],
+    "durationMs": 6092,
+    "usage": {
+      "prompt": 604,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 779
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1948",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が犬（動物）であるが、うつ病（depression）ではなく呼吸抑制（respiratory depression）に関連する研究と推定されるため除外"
+    ],
+    "durationMs": 4800,
+    "usage": {
+      "prompt": 408,
+      "completion": 122,
+      "reasoning": 0,
+      "total": 530
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1949",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や鎮痛などの文脈で使われており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 4313,
+    "usage": {
+      "prompt": 716,
+      "completion": 102,
+      "reasoning": 0,
+      "total": 818
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1950",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "対象がシナモンザル（Macaca fascicularis）という動物であり、産後うつ病の行動モデルに関するin vivo動物研究であるため"
+    ],
+    "durationMs": 6353,
+    "usage": {
+      "prompt": 814,
+      "completion": 187,
+      "reasoning": 0,
+      "total": 1001
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1951",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心筋抑制（myocardial depression）を指しており、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5056,
+    "usage": {
+      "prompt": 744,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 859
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1952",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がヒト（小児）であり、動物モデルではない",
+      "「depression」が免疫不全（immunocompetence depression）を指しており、うつ病ではない"
+    ],
+    "durationMs": 7106,
+    "usage": {
+      "prompt": 872,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 1039
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1953",
+    "label_included": 1,
+    "include_probability": 0.3,
+    "reasons": [
+      "タイトルに「antidepressant drugs」とあるが、対象が動物か人間か不明であり、抄録が存在しないため判断できない",
+      "「depression」がうつ病を指すか、あるいは他の意味（例：呼吸抑制）かが不明"
+    ],
+    "durationMs": 4622,
+    "usage": {
+      "prompt": 407,
+      "completion": 126,
+      "reasoning": 0,
+      "total": 533
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1954",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究対象がうつ病モデルではなく、心筋における薬理作用の評価であり、精神疾患としてのうつ病とは無関係である"
+    ],
+    "durationMs": 7861,
+    "usage": {
+      "prompt": 684,
+      "completion": 228,
+      "reasoning": 0,
+      "total": 912
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1955",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が中枢神経系抑制（CNS depression）を指しており、うつ病モデルではない",
+      "対象が犬であり動物実験ではあるが、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5402,
+    "usage": {
+      "prompt": 862,
+      "completion": 141,
+      "reasoning": 0,
+      "total": 1003
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1956",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "タイトルに「Clinical observations」とあり、ヒト臨床観察を示唆しているため動物研究ではない可能性が高い",
+      "「depression」が言及されておらず、うつ病モデルの研究かどうか不明"
+    ],
+    "durationMs": 4244,
+    "usage": {
+      "prompt": 407,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 516
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1957",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、てんかん発作およびGABA作動性抑制の電気生理学的研究である"
+    ],
+    "durationMs": 6091,
+    "usage": {
+      "prompt": 718,
+      "completion": 150,
+      "reasoning": 0,
+      "total": 868
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1958",
+    "label_included": 1,
+    "include_probability": 0,
+    "reasons": [
+      "in vitro 研究であり、in vivo 動物モデルではない"
+    ],
+    "durationMs": 5273,
+    "usage": {
+      "prompt": 968,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 1102
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1959",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病モデル（慢性予測不能ストレス誘導）に関するin vivo動物実験であり、対象がヒトでなく、呼吸・心臓の抑制など他の意味での「depression」ではない"
+    ],
+    "durationMs": 7235,
+    "usage": {
+      "prompt": 805,
+      "completion": 194,
+      "reasoning": 0,
+      "total": 999
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1960",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "研究は心臓の伝導抑制（cardiac depression）に関するものであり、うつ病（depression）の動物モデルではない"
+    ],
+    "durationMs": 5310,
+    "usage": {
+      "prompt": 1046,
+      "completion": 146,
+      "reasoning": 0,
+      "total": 1192
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1961",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、ラット副腎皮質調製物を用いたin vitro実験である"
+    ],
+    "durationMs": 4610,
+    "usage": {
+      "prompt": 850,
+      "completion": 118,
+      "reasoning": 0,
+      "total": 968
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1962",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした疫学調査であり、動物モデルのうつ病研究ではない"
+    ],
+    "durationMs": 4667,
+    "usage": {
+      "prompt": 879,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 998
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1963",
+    "label_included": 1,
+    "include_probability": 0.5,
+    "reasons": [
+      "タイトルに「抗うつ薬」とあるが、動物モデルを用いた研究かどうかは抄録がないため判断できない",
+      "うつ病の動物モデルに関する研究の可能性があるため、感度を優先して中立的確率を付与"
+    ],
+    "durationMs": 4818,
+    "usage": {
+      "prompt": 411,
+      "completion": 121,
+      "reasoning": 0,
+      "total": 532
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1964",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "マウスを用いたうつ病のin vivoモデルに関する動物実験であり、対象とする研究に該当する"
+    ],
+    "durationMs": 6189,
+    "usage": {
+      "prompt": 842,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 1009
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1965",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルから、うつ病の動物モデルに関する研究ではなく、射精および自律神経薬の影響を調べた研究であると判断される"
+    ],
+    "durationMs": 4541,
+    "usage": {
+      "prompt": 407,
+      "completion": 115,
+      "reasoning": 0,
+      "total": 522
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1966",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が神経生理学的な活動依存性抑制（活動依存性の放電抑制）を指しており、うつ病（depression as a mood disorder）の動物モデルではない",
+      "Aplysia（ミミズゴカイ）を用いた研究だが、うつ病の行動学的または病理学的モデルではなく、感覚ニューロンの放電特性に関する研究"
+    ],
+    "durationMs": 7740,
+    "usage": {
+      "prompt": 936,
+      "completion": 226,
+      "reasoning": 0,
+      "total": 1162
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1967",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がハエの生殖器に関する動物形態学的研究であり、うつ病のin vivoモデルを扱っていない"
+    ],
+    "durationMs": 2579,
+    "usage": {
+      "prompt": 734,
+      "completion": 57,
+      "reasoning": 0,
+      "total": 791
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1968",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたin vivo実験であり、うつ病関連の神経機構（ストレス関連精神障害）を調べているため"
+    ],
+    "durationMs": 6438,
+    "usage": {
+      "prompt": 1290,
+      "completion": 175,
+      "reasoning": 0,
+      "total": 1465
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1969",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルを対象とした研究ではなく、不安行動（anxiolytic効果）に関する動物実験である"
+    ],
+    "durationMs": 5755,
+    "usage": {
+      "prompt": 613,
+      "completion": 167,
+      "reasoning": 0,
+      "total": 780
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1970",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が呼吸抑制や心臓抑制などの生理学的抑制を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5639,
+    "usage": {
+      "prompt": 788,
+      "completion": 142,
+      "reasoning": 0,
+      "total": 930
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1971",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が心臓の伝導抑制（conduction depression）を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 5045,
+    "usage": {
+      "prompt": 794,
+      "completion": 123,
+      "reasoning": 0,
+      "total": 917
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1972",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が呼吸抑制や心機能抑制ではなく、シナプスの短期抑制（short-term synaptic depression）を指しており、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 6226,
+    "usage": {
+      "prompt": 692,
+      "completion": 172,
+      "reasoning": 0,
+      "total": 864
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1973",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病の動物モデルに関する研究ではなく、骨形成に関する研究である"
+    ],
+    "durationMs": 4193,
+    "usage": {
+      "prompt": 786,
+      "completion": 88,
+      "reasoning": 0,
+      "total": 874
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1974",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が気温や代謝の低下を指しており、うつ病（depression）の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 6946,
+    "usage": {
+      "prompt": 791,
+      "completion": 189,
+      "reasoning": 0,
+      "total": 980
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1975",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象が寄生虫の形態学的変化に関する動物実験であり、うつ病（depression）の研究ではない"
+    ],
+    "durationMs": 4579,
+    "usage": {
+      "prompt": 810,
+      "completion": 119,
+      "reasoning": 0,
+      "total": 929
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1976",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "非ヒト霊長類（シナモンガオホリザル）を用いたうつ病モデルに関する動物実験であり、対象がin vivoモデルであることが明確"
+    ],
+    "durationMs": 5934,
+    "usage": {
+      "prompt": 826,
+      "completion": 170,
+      "reasoning": 0,
+      "total": 996
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1977",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が免疫反応の抑制を指しており、うつ病モデルではない"
+    ],
+    "durationMs": 3601,
+    "usage": {
+      "prompt": 542,
+      "completion": 92,
+      "reasoning": 0,
+      "total": 634
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1978",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "ヒトを対象とした研究であり、動物モデルを用いていないため"
+    ],
+    "durationMs": 3680,
+    "usage": {
+      "prompt": 618,
+      "completion": 97,
+      "reasoning": 0,
+      "total": 715
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1979",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は長期抑制（long-term depression, LTD）を指しており、うつ病（depression）の動物モデルではない",
+      "対象は認知柔軟性や学習記憶に関する神経機構であり、うつ病の研究ではない"
+    ],
+    "durationMs": 5128,
+    "usage": {
+      "prompt": 620,
+      "completion": 130,
+      "reasoning": 0,
+      "total": 750
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1980",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「depression」とあるが、文脈から免疫反応の抑制を指しており、うつ病（depression）の動物モデルではない可能性が高い",
+      "対象がウサギであるが、うつ病モデルではなく放射線による免疫応答の変化を調べている"
+    ],
+    "durationMs": 5919,
+    "usage": {
+      "prompt": 425,
+      "completion": 131,
+      "reasoning": 0,
+      "total": 556
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1981",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルに「depression」が含まれておらず、うつ病の動物モデルに関する研究であることを示す根拠がない",
+      "「depression」が呼吸抑制や心機能抑制などを指す可能性も含めて、うつ病とは無関係と判断される"
+    ],
+    "durationMs": 5025,
+    "usage": {
+      "prompt": 409,
+      "completion": 89,
+      "reasoning": 0,
+      "total": 498
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1982",
+    "label_included": 0,
+    "include_probability": 0.1,
+    "reasons": [
+      "「central depressant」とあるが、これは中枢神経抑制作用を指しており、うつ病（depression）の動物モデルを対象としている可能性は極めて低い",
+      "「depression」が呼吸抑制や心機能抑制などを意味する可能性があり、うつ病とは無関係と判断される"
+    ],
+    "durationMs": 7096,
+    "usage": {
+      "prompt": 404,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 539
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1983",
+    "label_included": 0,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病関連の動物実験であり、in vivoモデルであることが明記されている"
+    ],
+    "durationMs": 5149,
+    "usage": {
+      "prompt": 708,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 842
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1984",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が創傷治癒の抑制を指しており、うつ病の動物モデルではない"
+    ],
+    "durationMs": 4344,
+    "usage": {
+      "prompt": 663,
+      "completion": 109,
+      "reasoning": 0,
+      "total": 772
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1985",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "タイトルおよび抄録にうつ病（depression）に関する記述がなく、研究対象が酵母（Saccharomyces cerevisiae）であり、うつ病のin vivo動物モデルの研究ではない"
+    ],
+    "durationMs": 4192,
+    "usage": {
+      "prompt": 430,
+      "completion": 77,
+      "reasoning": 0,
+      "total": 507
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1986",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は骨髄抑制による白血球減少（neutropeniaやleukocyte depression）を指しており、うつ病（depression）ではない",
+      "対象はマウスであるが、うつ病の動物モデルに関する研究ではない"
+    ],
+    "durationMs": 6525,
+    "usage": {
+      "prompt": 1098,
+      "completion": 181,
+      "reasoning": 0,
+      "total": 1279
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1987",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」が肝細胞機能の低下を指しており、うつ病（depression）の動物モデルではない",
+      "対象は敗血症における肝機能障害であり、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 6192,
+    "usage": {
+      "prompt": 679,
+      "completion": 169,
+      "reasoning": 0,
+      "total": 848
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1988",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は精神疾患としてのうつ病ではなく、組織スコアの低下（testicular biopsy scoreの低下）を指しており、対象外である",
+      "研究は精巣損傷に関するもので、うつ病のin vivoモデルではない"
+    ],
+    "durationMs": 5276,
+    "usage": {
+      "prompt": 599,
+      "completion": 132,
+      "reasoning": 0,
+      "total": 731
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1989",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "うつ病のin vivoモデルに関する研究ではなく、赤血球造血ホルモン（エリスロポエチン）による移植片対宿主反応および末梢白血球の変化を調べた免疫学的研究である"
+    ],
+    "durationMs": 4437,
+    "usage": {
+      "prompt": 579,
+      "completion": 82,
+      "reasoning": 0,
+      "total": 661
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1990",
+    "label_included": 1,
+    "include_probability": 1,
+    "reasons": [
+      "ラットを用いたうつ病モデルに関する動物実験であり、うつ病様行動を評価している"
+    ],
+    "durationMs": 4801,
+    "usage": {
+      "prompt": 523,
+      "completion": 135,
+      "reasoning": 0,
+      "total": 658
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1991",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」は血管の反応性低下（生理学的抑制）を指しており、うつ病（depression）の動物モデルに関する研究ではない",
+      "対象はハムスター大動脈の血管反応性で、行動学的または神経生物学的なうつ病モデルではない",
+      "「respiratory depression」や「cardiac depression」と同様に、「depression」は機能抑制を意味しており、精神疾患としてのうつ病とは無関係"
+    ],
+    "durationMs": 8610,
+    "usage": {
+      "prompt": 854,
+      "completion": 243,
+      "reasoning": 0,
+      "total": 1097
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1992",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "「depression」という用語が神経活動の抑制（GABA-elicited depression）を指しており、うつ病モデルではない",
+      "動物実験ではあるが、うつ病のin vivoモデルに関する記述が全くない"
+    ],
+    "durationMs": 4861,
+    "usage": {
+      "prompt": 773,
+      "completion": 134,
+      "reasoning": 0,
+      "total": 907
+    }
+  },
+  {
+    "ref_id": "Depression-SLIM-1993",
+    "label_included": 0,
+    "include_probability": 0,
+    "reasons": [
+      "対象がラット肝細胞の初代培養であり、in vivoモデルではない",
+      "「depression」という語はビタミンEおよびCの低下を指しており、うつ病とは無関係"
+    ],
+    "durationMs": 5958,
+    "usage": {
+      "prompt": 687,
+      "completion": 164,
+      "reasoning": 0,
+      "total": 851
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tiab-review-plugin",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "description": "TiAb Review Plugin - Chrome Extension for Systematic Review Screening",
     "private": true,
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extName__",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "default_locale": "ja",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxleBKT1/T3XzlZhHEB2GjyDLIkQ8exz7ZfAx7IvDB6PMWnrwJ6Cv9SPqAJ9FxF3OSGcobjwQzYt+xBbXVZgBuvcj1mvIekDZ3jH0QeZH8HWVKAjHkGJdiAMocrR1TsOO9bAUyFiYv/R8/4/qk+b9jve0aosK2PPb80+p4GekjhDVXRVfg6Q7gKjbZitR2g/MGCQH+qHOAusyYrjoE62luQC9EfIPYxAJ4XFtxsfhOcDal990Ln9w8pchQGHjoWDc+D74LHhl2umc+9GbEXj78m5fO2CRJgTU+ETH/vIdmDi4QgmzLMkw2GWAXr/TSUenIigMAdexpDYPL+nqHk8LCwIDAQAB",
     "description": "__MSG_extDescription__",

--- a/src/sidepanel/features/screening/filters.ts
+++ b/src/sidepanel/features/screening/filters.ts
@@ -241,28 +241,21 @@ export function getFilteredReferences(): ReferenceWithStatus[] {
         }
     }
 
-    // AI判定フィルター (Blind off時のみ、かつ少なくとも1つチェックが外れている場合)
-    if (state.isKeyOpened && (!state.aiDecisionFilter.include || !state.aiDecisionFilter.exclude)) {
-        filtered = filtered.filter(r => {
-            // AI判定を取得
-            const aiDecisions = r.allDecisions?.filter(d => d.reviewer_id.startsWith('llm:')) || [];
+    // AI判定フィルター (Blind off時のみ、AIレビュアーごとに独立して適用)
+    if (state.isKeyOpened) {
+        for (const [reviewerId, filter] of Object.entries(state.aiDecisionFilter)) {
+            const allowed = new Set<string>();
+            if (filter.include) allowed.add('include');
+            if (filter.exclude) allowed.add('exclude');
+            // 両方ON or 両方OFF はこのAIのフィルターを適用しない
+            if (allowed.size === 2 || allowed.size === 0) continue;
 
-            // AI判定がない場合は常に表示（フィルター対象外）
-            if (aiDecisions.length === 0) return true;
-
-            // AI判定がある場合、表示許可されている判定が1つでもあればOK
-            // Include許可 かつ Include判定がある -> OK
-            // Exclude許可 かつ Exclude判定がある -> OK
-            const hasAllowedDecision = aiDecisions.some(d => {
-                if (d.decision === 'include' && state.aiDecisionFilter.include) return true;
-                if (d.decision === 'exclude' && state.aiDecisionFilter.exclude) return true;
-                // maybe, pending, conflict等はフィルター対象外として表示
-                if (d.decision !== 'include' && d.decision !== 'exclude') return true;
-                return false;
+            filtered = filtered.filter(r => {
+                const aiDecision = r.allDecisions?.find(d => d.reviewer_id === reviewerId);
+                if (!aiDecision) return false; // 該当AIの判定が無いレコードは非表示
+                return allowed.has(aiDecision.decision);
             });
-
-            return hasAllowedDecision;
-        });
+        }
     }
 
     return filtered;

--- a/src/sidepanel/features/screening/reviewer-filter.ts
+++ b/src/sidepanel/features/screening/reviewer-filter.ts
@@ -145,14 +145,17 @@ export function renderReviewerFilter() {
             includeLabel.style.gap = '2px';
             includeLabel.style.cursor = 'pointer';
 
+            const currentFilter = state.aiDecisionFilter[reviewerId] ?? { include: true, exclude: true };
+
             const includeCheckbox = document.createElement('input');
             includeCheckbox.type = 'checkbox';
-            includeCheckbox.checked = state.aiDecisionFilter.include;
+            includeCheckbox.checked = currentFilter.include;
             includeCheckbox.addEventListener('change', (e) => {
                 e.stopPropagation();
+                const prev = state.aiDecisionFilter[reviewerId] ?? { include: true, exclude: true };
                 state.setAiDecisionFilter({
                     ...state.aiDecisionFilter,
-                    include: includeCheckbox.checked
+                    [reviewerId]: { ...prev, include: includeCheckbox.checked }
                 });
                 // フィルター適用のためインデックスをリセットして再描画
                 state.setCurrentIndex(0);
@@ -175,12 +178,13 @@ export function renderReviewerFilter() {
 
             const excludeCheckbox = document.createElement('input');
             excludeCheckbox.type = 'checkbox';
-            excludeCheckbox.checked = state.aiDecisionFilter.exclude;
+            excludeCheckbox.checked = currentFilter.exclude;
             excludeCheckbox.addEventListener('change', (e) => {
                 e.stopPropagation();
+                const prev = state.aiDecisionFilter[reviewerId] ?? { include: true, exclude: true };
                 state.setAiDecisionFilter({
                     ...state.aiDecisionFilter,
-                    exclude: excludeCheckbox.checked
+                    [reviewerId]: { ...prev, exclude: excludeCheckbox.checked }
                 });
                 // フィルター適用のためインデックスをリセットして再描画
                 state.setCurrentIndex(0);

--- a/src/sidepanel/sidepanel.html
+++ b/src/sidepanel/sidepanel.html
@@ -14,7 +14,7 @@
         <header class="header">
             <div id="header-title" class="header-title" style="cursor: pointer;" data-i18n-title="nav_backToProject">
                 <h1>TiAb Review</h1>
-                <span class="build-version">Build: 2026-05-24</span>
+                <span class="build-version">Build: 2026-05-26</span>
             </div>
             <div class="header-tabs hidden">
                 <button id="tab-screening" class="tab-btn active" data-i18n-title="nav_tabManualTitle" data-i18n="nav_tabManual"></button>

--- a/src/sidepanel/state.ts
+++ b/src/sidepanel/state.ts
@@ -66,7 +66,7 @@ let _failedRefIds: string[] = [];  // リトライ対象の失敗ref_id
 let _enabledReviewers: Set<string> = new Set(); // 表示対象のレビュアーID
 let _availableReviewers: Set<string> = new Set(); // 利用可能な全レビュアーID
 let _showAiHighlights = false; // AIのEvidenceをハイライトするかどうか
-let _aiDecisionFilter = { include: true, exclude: true }; // AI判定の表示フィルター
+let _aiDecisionFilter: Record<string, { include: boolean; exclude: boolean }> = {}; // AI判定の表示フィルター（AIレビュアーID別）
 let _treatMlAsManual = true; // ML判定を手動判定と同一視するか
 
 import { createInitialMlState, MlState } from '../lib/ml/types';
@@ -254,7 +254,7 @@ export const state = {
     setShowAiHighlights(show: boolean) { _showAiHighlights = show; },
 
     get aiDecisionFilter() { return _aiDecisionFilter; },
-    setAiDecisionFilter(filter: { include: boolean; exclude: boolean }) { _aiDecisionFilter = filter; },
+    setAiDecisionFilter(filter: Record<string, { include: boolean; exclude: boolean }>) { _aiDecisionFilter = filter; },
 
     get treatMlAsManual() { return _treatMlAsManual; },
     setTreatMlAsManual(value: boolean) { _treatMlAsManual = value; },

--- a/src/sidepanel/store/reducer.ts
+++ b/src/sidepanel/store/reducer.ts
@@ -59,7 +59,7 @@ export const initialState: AppState = {
             termFilterUseAnd: true,
             treatMlAsManual: true,
             showAiHighlights: false,
-            aiDecisionFilter: { include: true, exclude: true },
+            aiDecisionFilter: {},
             abstractSubsectionBreakEnabled: false,
             abstractSubsectionHeadings: [],
         },

--- a/src/sidepanel/store/selectors.ts
+++ b/src/sidepanel/store/selectors.ts
@@ -158,22 +158,21 @@ export function getFilteredReferences(state: AppState): ReferenceWithStatus[] {
         }
     }
 
-    // AI判定フィルター (Blind off時のみ)
-    if (screening.isKeyOpened &&
-        (!settings.aiDecisionFilter.include || !settings.aiDecisionFilter.exclude)) {
-        filtered = filtered.filter(r => {
-            const aiDecisions = r.allDecisions?.filter(d => d.reviewer_id.startsWith('llm:')) || [];
-            if (aiDecisions.length === 0) return true;
+    // AI判定フィルター (Blind off時のみ、AIレビュアーごとに独立して適用)
+    if (screening.isKeyOpened) {
+        for (const [reviewerId, filter] of Object.entries(settings.aiDecisionFilter)) {
+            const allowed = new Set<string>();
+            if (filter.include) allowed.add('include');
+            if (filter.exclude) allowed.add('exclude');
+            // 両方ON or 両方OFF はこのAIのフィルターを適用しない
+            if (allowed.size === 2 || allowed.size === 0) continue;
 
-            const hasAllowedDecision = aiDecisions.some(d => {
-                if (d.decision === 'include' && settings.aiDecisionFilter.include) return true;
-                if (d.decision === 'exclude' && settings.aiDecisionFilter.exclude) return true;
-                if (d.decision !== 'include' && d.decision !== 'exclude') return true;
-                return false;
+            filtered = filtered.filter(r => {
+                const aiDecision = r.allDecisions?.find(d => d.reviewer_id === reviewerId);
+                if (!aiDecision) return false; // 該当AIの判定が無いレコードは非表示
+                return allowed.has(aiDecision.decision);
             });
-
-            return hasAllowedDecision;
-        });
+        }
     }
 
     return filtered;

--- a/src/sidepanel/store/types.ts
+++ b/src/sidepanel/store/types.ts
@@ -97,7 +97,7 @@ export interface AppState {
             termFilterUseAnd: boolean;
             treatMlAsManual: boolean;
             showAiHighlights: boolean;
-            aiDecisionFilter: { include: boolean; exclude: boolean };
+            aiDecisionFilter: Record<string, { include: boolean; exclude: boolean }>;
             abstractSubsectionBreakEnabled: boolean;
             abstractSubsectionHeadings: string[];
         };
@@ -177,7 +177,7 @@ export type Action =
     | { type: 'settings/setTermFilterUseAnd'; value: boolean }
     | { type: 'settings/setTreatMlAsManual'; value: boolean }
     | { type: 'settings/setShowAiHighlights'; value: boolean }
-    | { type: 'settings/setAiDecisionFilter'; filter: { include: boolean; exclude: boolean } }
+    | { type: 'settings/setAiDecisionFilter'; filter: Record<string, { include: boolean; exclude: boolean }> }
     | { type: 'settings/setAbstractSubsectionBreakEnabled'; value: boolean }
     | { type: 'settings/setAbstractSubsectionHeadings'; value: string[] }
 


### PR DESCRIPTION
## Summary

- AI判定フィルター (`aiDecisionFilter`) を全AI共通の `{ include, exclude }` から、AIレビュアーIDごとに独立した `Record<reviewerId, { include, exclude }>` 構造へ変更。レビュアー別にinclude/excludeを個別に絞り込めるようになり、UIチェックボックスもレビュアー単位で動作。
- OpenRouter経由のQwen3 Maxベンチマーク (OR-Q3) の実験ログと結果JSONを追加。
- バージョンを 0.20.1 へ更新（package.json / manifest.json / Buildラベル）。

## Test plan

- [ ] Blind off状態で複数のAIレビュアーがあるプロジェクトを開き、各AIのinclude/excludeチェックボックスを切り替えて独立にフィルターされることを確認
- [ ] 片方のチェックのみON（例: includeのみ）のとき、対象AIの判定がないレコードが非表示になることを確認
- [ ] 両方ON / 両方OFFのとき該当AIによる絞り込みが行われないことを確認
- [ ] 既存設定（旧形式の `aiDecisionFilter`）を持つユーザの起動時に例外が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)