### PR TITLE
feat: スクリーニングのフィルタ/状態管理リファクタ＋AI根拠ハイライトを全ユーザー表示・デフォルトON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tiab-review-plugin",
-    "version": "0.20.1",
+    "version": "0.20.2",
     "description": "TiAb Review Plugin - Chrome Extension for Systematic Review Screening",
     "private": true,
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extName__",
-    "version": "0.20.1",
+    "version": "0.20.2",
     "default_locale": "ja",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxleBKT1/T3XzlZhHEB2GjyDLIkQ8exz7ZfAx7IvDB6PMWnrwJ6Cv9SPqAJ9FxF3OSGcobjwQzYt+xBbXVZgBuvcj1mvIekDZ3jH0QeZH8HWVKAjHkGJdiAMocrR1TsOO9bAUyFiYv/R8/4/qk+b9jve0aosK2PPb80+p4GekjhDVXRVfg6Q7gKjbZitR2g/MGCQH+qHOAusyYrjoE62luQC9EfIPYxAJ4XFtxsfhOcDal990Ln9w8pchQGHjoWDc+D74LHhl2umc+9GbEXj78m5fO2CRJgTU+ETH/vIdmDi4QgmzLMkw2GWAXr/TSUenIigMAdexpDYPL+nqHk8LCwIDAQAB",
     "description": "__MSG_extDescription__",

--- a/src/sidepanel/features/project.ts
+++ b/src/sidepanel/features/project.ts
@@ -421,8 +421,9 @@ export async function loadDataAndShowScreening() {
             console.log('[loadDataAndShowScreening] Admin mode');
             if (_renderKeyStatus) _renderKeyStatus();
             if (_renderReviewerFilter) _renderReviewerFilter();
-            if (_renderAiHighlightToggle) _renderAiHighlightToggle();
         }
+        // AIハイライトトグルは全ユーザーに表示（確定AI判定があれば表示される）
+        if (_renderAiHighlightToggle) _renderAiHighlightToggle();
         renderAssignmentManager();
 
         // スクリーニング画面を表示（Store経由でrenderLayoutが自動更新）

--- a/src/sidepanel/features/screening/filters.ts
+++ b/src/sidepanel/features/screening/filters.ts
@@ -13,6 +13,7 @@ import { deleteReferencesBySourceFile } from '../../../lib/sheets-api';
 import { showToast, showLoading } from '../../ui/feedback';
 import { isHumanDecision, isConfirmedMlDecision, isMlDecision } from '../../../lib/client-version';
 import { getReferenceAssignmentSet } from '../assignment';
+import { computeReviewerKey, hasEffectiveConflict } from '../../render/helpers';
 
 // Store互換レイヤー（Phase 3）
 import {
@@ -47,10 +48,17 @@ function isFulltextCandidate(r: ReferenceWithStatus): boolean {
 
     const userEmail = state.userEmail;
 
+    // 無効化されたレビュアーの判定は無視（Blind OFF 時のみ）
+    const isReviewerEnabled = (d: Decision): boolean => {
+        if (!state.isKeyOpened) return true;
+        const key = computeReviewerKey(d, state.treatMlAsManual);
+        return key !== '' && state.enabledReviewers.has(key);
+    };
+
     // ヘルパー: 特定の条件でInclude判定があるか
     const hasInclude = (check: (d: Decision) => boolean) => {
-        return (r.allDecisions?.some(d => check(d) && d.decision === 'include')) ||
-            (r.myDecision && check(r.myDecision) && r.myDecision.decision === 'include');
+        return (r.allDecisions?.some(d => isReviewerEnabled(d) && check(d) && d.decision === 'include')) ||
+            (r.myDecision && isReviewerEnabled(r.myDecision) && check(r.myDecision) && r.myDecision.decision === 'include');
     };
 
     // 1. 手動判定（複数人対応）
@@ -112,7 +120,8 @@ function isFulltextCandidate(r: ReferenceWithStatus): boolean {
     // 3. LLM判定 - reviewer_idがllm:で始まる判定
     const llmInclude = r.allDecisions?.some(d =>
         d.reviewer_id.startsWith('llm:') &&
-        d.decision === 'include'
+        d.decision === 'include' &&
+        isReviewerEnabled(d)
     );
 
     if (llmInclude) includeCategories++;
@@ -177,8 +186,10 @@ export function getFilteredReferences(): ReferenceWithStatus[] {
     if (state.currentFilter === 'fulltext_candidates') {
         filtered = filtered.filter(isFulltextCandidate);
     } else if (state.currentFilter === 'conflict') {
-        // 不一致は合成ステータスをそのまま使用
-        filtered = filtered.filter((r) => r.status === 'conflict');
+        // 不一致は enabledReviewers を反映して動的に計算
+        filtered = filtered.filter((r) =>
+            hasEffectiveConflict(r, state.enabledReviewers, state.isKeyOpened, state.treatMlAsManual)
+        );
     } else if (state.currentFilter !== 'all') {
         // pending, include, exclude, maybe は自分の手動判定(0.1.0)でフィルタリング
         filtered = filtered.filter((r) => getMyManualDecisionStatus(r) === state.currentFilter);
@@ -241,19 +252,22 @@ export function getFilteredReferences(): ReferenceWithStatus[] {
         }
     }
 
-    // AI判定フィルター (Blind off時のみ、AIレビュアーごとに独立して適用)
+    // 判定フィルター (Blind off時のみ、レビュアーごとに独立して適用)
     if (state.isKeyOpened) {
         for (const [reviewerId, filter] of Object.entries(state.aiDecisionFilter)) {
+            // 無効化されたレビュアーはフィルター対象外
+            if (!state.enabledReviewers.has(reviewerId)) continue;
+
             const allowed = new Set<string>();
             if (filter.include) allowed.add('include');
             if (filter.exclude) allowed.add('exclude');
-            // 両方ON or 両方OFF はこのAIのフィルターを適用しない
+            // 両方ON or 両方OFF はこのレビュアーのフィルターを適用しない
             if (allowed.size === 2 || allowed.size === 0) continue;
 
             filtered = filtered.filter(r => {
-                const aiDecision = r.allDecisions?.find(d => d.reviewer_id === reviewerId);
-                if (!aiDecision) return false; // 該当AIの判定が無いレコードは非表示
-                return allowed.has(aiDecision.decision);
+                const decision = r.allDecisions?.find(d => d.reviewer_id === reviewerId);
+                if (!decision) return false; // 該当レビュアーの判定が無いレコードは非表示
+                return allowed.has(decision.decision);
             });
         }
     }
@@ -281,7 +295,9 @@ export function updateFilterCounts() {
         include: filtered.filter(r => getMyManualDecisionStatus(r) === 'include').length,
         exclude: filtered.filter(r => getMyManualDecisionStatus(r) === 'exclude').length,
         maybe: filtered.filter(r => getMyManualDecisionStatus(r) === 'maybe').length,
-        conflict: filtered.filter(r => r.status === 'conflict').length,  // 不一致は合成ステータス
+        conflict: filtered.filter(r =>
+            hasEffectiveConflict(r, state.enabledReviewers, state.isKeyOpened, state.treatMlAsManual)
+        ).length,
     };
 
     const options = dom.statusFilter.options;

--- a/src/sidepanel/features/screening/render.ts
+++ b/src/sidepanel/features/screening/render.ts
@@ -9,7 +9,7 @@ import { escapeHtml, escapeRegex } from '../../utils/text';
 import { getFilteredReferences, updateFilterCounts, getMyManualDecisionStatus } from './filters';
 import type { ReferenceWithStatus } from '../../../lib/types';
 import { getReviewerKey, getReviewerLabel, isActiveConfirmedLlmDecision } from './reviewer-utils';
-import { detectConflictWithSettings } from '../../render/helpers';
+import { detectConflictWithSettings, filterEnabledDecisions } from '../../render/helpers';
 import { isHumanDecision, isConfirmedMlDecision, isMlAutoDecision, isMlDecision } from '../../../lib/client-version';
 import { t } from '../../../lib/i18n';
 import type { DecisionStatus } from '../../../lib/types';
@@ -225,9 +225,15 @@ export function renderSpecificReference(ref: ReferenceWithStatus) {
  * 特定の文献を描画（内部関数）
  */
 function renderReferenceDetails(ref: ReferenceWithStatus, totalFiltered: number, isHistoryView: boolean) {
-    // コンフリクト表示（treatMlAsManual設定を考慮して動的に計算）
-    const hasConflict = ref.allDecisions && ref.allDecisions.length > 0
-        ? detectConflictWithSettings(ref.allDecisions, state.treatMlAsManual)
+    // コンフリクト表示（enabledReviewers と treatMlAsManual を反映して動的に計算）
+    const conflictDecisions = filterEnabledDecisions(
+        ref.allDecisions,
+        state.enabledReviewers,
+        state.isKeyOpened,
+        state.treatMlAsManual
+    );
+    const hasConflict = conflictDecisions.length > 0
+        ? detectConflictWithSettings(conflictDecisions, state.treatMlAsManual)
         : false;
     if (state.isKeyOpened && ref.allDecisions && ref.allDecisions.length > 0) {
         renderAllDecisions(ref);

--- a/src/sidepanel/features/screening/reviewer-filter.ts
+++ b/src/sidepanel/features/screening/reviewer-filter.ts
@@ -107,7 +107,8 @@ export function renderReviewerFilter() {
         const mlKey = reviewerId + ML_REVIEWER_SUFFIX;
         const isEnabledBase = state.enabledReviewers.has(reviewerId);
         const isEnabledMl = state.treatMlAsManual && isMixed && state.enabledReviewers.has(mlKey);
-        checkbox.checked = isEnabledBase || isEnabledMl;
+        const isReviewerEnabled = isEnabledBase || isEnabledMl;
+        checkbox.checked = isReviewerEnabled;
         checkbox.dataset.reviewer = reviewerId;
 
         checkbox.addEventListener('change', () => {
@@ -120,102 +121,71 @@ export function renderReviewerFilter() {
             } else {
                 handleReviewerToggle(reviewerId, checkbox.checked);
             }
+            // disabled 表示を更新するため、レビュアーフィルター UI を再描画
+            renderReviewerFilter();
         });
 
         const nameSpan = document.createElement('span');
         // 混在情報を含むラベルを表示
         nameSpan.textContent = getReviewerLabel(reviewerId, state.userEmail, isMixed);
 
-        // AIの場合の装飾
         if (isLlmReviewerKey(reviewerId)) {
             nameSpan.classList.add('reviewer-llm');
-
-
-            // AI判定フィルター（AIレビュアーの右側に配置）
-            const filterContainer = document.createElement('div');
-            filterContainer.style.display = 'flex';
-            filterContainer.style.gap = '8px';
-            filterContainer.style.marginLeft = 'auto';
-            filterContainer.style.fontSize = '0.85em';
-
-            // Include filter
-            const includeLabel = document.createElement('label');
-            includeLabel.style.display = 'flex';
-            includeLabel.style.alignItems = 'center';
-            includeLabel.style.gap = '2px';
-            includeLabel.style.cursor = 'pointer';
-
-            const currentFilter = state.aiDecisionFilter[reviewerId] ?? { include: true, exclude: true };
-
-            const includeCheckbox = document.createElement('input');
-            includeCheckbox.type = 'checkbox';
-            includeCheckbox.checked = currentFilter.include;
-            includeCheckbox.addEventListener('change', (e) => {
-                e.stopPropagation();
-                const prev = state.aiDecisionFilter[reviewerId] ?? { include: true, exclude: true };
-                state.setAiDecisionFilter({
-                    ...state.aiDecisionFilter,
-                    [reviewerId]: { ...prev, include: includeCheckbox.checked }
-                });
-                // フィルター適用のためインデックスをリセットして再描画
-                state.setCurrentIndex(0);
-                if (_renderCurrentReference) _renderCurrentReference();
-            });
-
-            const includeSpan = document.createElement('span');
-            includeSpan.textContent = t('filter_includeDecision');
-            includeSpan.title = t('filter_includeLabel');
-
-            includeLabel.appendChild(includeCheckbox);
-            includeLabel.appendChild(includeSpan);
-
-            // Exclude filter
-            const excludeLabel = document.createElement('label');
-            excludeLabel.style.display = 'flex';
-            excludeLabel.style.alignItems = 'center';
-            excludeLabel.style.gap = '2px';
-            excludeLabel.style.cursor = 'pointer';
-
-            const excludeCheckbox = document.createElement('input');
-            excludeCheckbox.type = 'checkbox';
-            excludeCheckbox.checked = currentFilter.exclude;
-            excludeCheckbox.addEventListener('change', (e) => {
-                e.stopPropagation();
-                const prev = state.aiDecisionFilter[reviewerId] ?? { include: true, exclude: true };
-                state.setAiDecisionFilter({
-                    ...state.aiDecisionFilter,
-                    [reviewerId]: { ...prev, exclude: excludeCheckbox.checked }
-                });
-                // フィルター適用のためインデックスをリセットして再描画
-                state.setCurrentIndex(0);
-                if (_renderCurrentReference) _renderCurrentReference();
-            });
-
-            const excludeSpan = document.createElement('span');
-            excludeSpan.textContent = t('filter_excludeDecision');
-            excludeSpan.title = t('filter_excludeLabel');
-
-            excludeLabel.appendChild(excludeCheckbox);
-            excludeLabel.appendChild(excludeSpan);
-
-            filterContainer.appendChild(includeLabel);
-            filterContainer.appendChild(excludeLabel);
-
-            // 先にラベルを追加（AI名）
-            label.appendChild(checkbox);
-            label.appendChild(nameSpan);
-            item.appendChild(label);
-
-            // その後にフィルターを右側に追加
-            item.style.display = 'flex';
-            item.style.alignItems = 'center';
-            item.appendChild(filterContainer);
-        } else {
-            // 人間のレビュアーは通常通り
-            label.appendChild(checkbox);
-            label.appendChild(nameSpan);
-            item.appendChild(label);
         }
+
+        // 判定フィルター（include / exclude）を AI / 人間ともに配置
+        const filterContainer = document.createElement('div');
+        filterContainer.style.display = 'flex';
+        filterContainer.style.gap = '8px';
+        filterContainer.style.marginLeft = 'auto';
+        filterContainer.style.fontSize = '0.85em';
+        if (!isReviewerEnabled) {
+            filterContainer.style.opacity = '0.4';
+        }
+
+        const currentFilter = state.aiDecisionFilter[reviewerId] ?? { include: true, exclude: true };
+
+        const buildDecisionToggle = (kind: 'include' | 'exclude') => {
+            const wrapper = document.createElement('label');
+            wrapper.style.display = 'flex';
+            wrapper.style.alignItems = 'center';
+            wrapper.style.gap = '2px';
+            wrapper.style.cursor = isReviewerEnabled ? 'pointer' : 'not-allowed';
+
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.checked = currentFilter[kind];
+            input.disabled = !isReviewerEnabled;
+            input.addEventListener('change', (e) => {
+                e.stopPropagation();
+                const prev = state.aiDecisionFilter[reviewerId] ?? { include: true, exclude: true };
+                state.setAiDecisionFilter({
+                    ...state.aiDecisionFilter,
+                    [reviewerId]: { ...prev, [kind]: input.checked }
+                });
+                state.setCurrentIndex(0);
+                if (_renderCurrentReference) _renderCurrentReference();
+            });
+
+            const text = document.createElement('span');
+            text.textContent = kind === 'include' ? t('filter_includeDecision') : t('filter_excludeDecision');
+            text.title = kind === 'include' ? t('filter_includeLabel') : t('filter_excludeLabel');
+
+            wrapper.appendChild(input);
+            wrapper.appendChild(text);
+            return wrapper;
+        };
+
+        filterContainer.appendChild(buildDecisionToggle('include'));
+        filterContainer.appendChild(buildDecisionToggle('exclude'));
+
+        label.appendChild(checkbox);
+        label.appendChild(nameSpan);
+        item.appendChild(label);
+        item.style.display = 'flex';
+        item.style.alignItems = 'center';
+        item.appendChild(filterContainer);
+
         list.appendChild(item);
     });
 }

--- a/src/sidepanel/render/helpers.ts
+++ b/src/sidepanel/render/helpers.ts
@@ -145,6 +145,62 @@ export function getMlBadgeHtml(clientVersion?: string): string {
 }
 
 /**
+ * Decision から reviewer の集約キーを計算する。
+ * `availableReviewers` / `enabledReviewers` に格納されているキーと一致する。
+ * - LLM: `reviewer_id` をそのまま
+ * - 人間 manual: email
+ * - 人間 ML 確認済み: treatMlAsManual=true なら email、false なら `email::ml`
+ * - 人間 ML auto: `email::ml`
+ */
+export function computeReviewerKey(
+    decision: import('../../lib/types').Decision,
+    treatMlAsManual: boolean
+): string {
+    const reviewerId = (decision.reviewer_id || '').trim();
+    if (!reviewerId) return '';
+    if (reviewerId.startsWith('llm:')) return reviewerId;
+    if (treatMlAsManual && isConfirmedMlDecision(decision.client_version)) {
+        return reviewerId;
+    }
+    if (isMlDecision(decision.client_version)) return `${reviewerId}::ml`;
+    return reviewerId;
+}
+
+/**
+ * 有効なレビュアーの判定のみを返す。
+ * Blind ON（`isKeyOpened=false`）時は全件返す（reviewer フィルター無効化）。
+ * Blind OFF 時は `enabledReviewers` に含まれるキーの判定のみ返す。
+ */
+export function filterEnabledDecisions(
+    decisions: import('../../lib/types').Decision[] | undefined,
+    enabledReviewers: Set<string>,
+    isKeyOpened: boolean,
+    treatMlAsManual: boolean
+): import('../../lib/types').Decision[] {
+    if (!decisions || decisions.length === 0) return [];
+    if (!isKeyOpened) return decisions;
+    return decisions.filter(d => {
+        const key = computeReviewerKey(d, treatMlAsManual);
+        return key !== '' && enabledReviewers.has(key);
+    });
+}
+
+/**
+ * 有効なレビュアーのみで不一致を検出する（Reference 単位）。
+ * Blind ON 時は `enabledReviewers` を無視して全レビュアーで検出する。
+ */
+export function hasEffectiveConflict(
+    ref: { allDecisions?: import('../../lib/types').Decision[] } | undefined,
+    enabledReviewers: Set<string>,
+    isKeyOpened: boolean,
+    treatMlAsManual: boolean
+): boolean {
+    if (!ref?.allDecisions || ref.allDecisions.length === 0) return false;
+    const decisions = filterEnabledDecisions(ref.allDecisions, enabledReviewers, isKeyOpened, treatMlAsManual);
+    return detectConflictWithSettings(decisions, treatMlAsManual);
+}
+
+/**
  * 不一致を検出（treatMlAsManual設定を考慮）
  * - treatMlAsManualがONの場合、同一ユーザーのML判定と手動判定を同一視
  * - 2人以上のレビュアーが存在し、判定内容が異なる場合のみ不一致

--- a/src/sidepanel/render/index.ts
+++ b/src/sidepanel/render/index.ts
@@ -6,7 +6,7 @@
 import type { AppState } from '../store/types';
 import { renderLayout, renderTemporaryUI, renderFilterOptions } from './layout';
 import { getFilterCounts, getProgressStats, getFilteredReferences, getCurrentReference, getAiEvidenceList } from '../store/selectors';
-import { highlightText, getEncourageMessage, getReviewerLabel, getDecisionIcon, getMlBadgeHtml, detectConflictWithSettings } from './helpers';
+import { highlightText, getEncourageMessage, getReviewerLabel, getDecisionIcon, getMlBadgeHtml, detectConflictWithSettings, filterEnabledDecisions } from './helpers';
 import { dom } from '../dom';
 import { isHumanDecision, isConfirmedMlDecision } from '../../lib/client-version';
 import { t } from '../../lib/i18n';
@@ -199,9 +199,15 @@ function renderReferenceDetails(
     dom.navPosition.textContent = `${state.ui.screening.currentIndex + 1} / ${totalFiltered}`;
     dom.filterResultCount.textContent = `${totalFiltered}件中 ${state.ui.screening.currentIndex + 1}件目`;
 
-    // コンフリクト表示（treatMlAsManual設定を考慮して動的に計算）
-    const hasConflict = ref.allDecisions && ref.allDecisions.length > 0
-        ? detectConflictWithSettings(ref.allDecisions, state.ui.settings.treatMlAsManual)
+    // コンフリクト表示（enabledReviewers と treatMlAsManual を反映して動的に計算）
+    const conflictDecisions = filterEnabledDecisions(
+        ref.allDecisions,
+        state.data.enabledReviewers,
+        state.ui.screening.isKeyOpened,
+        state.ui.settings.treatMlAsManual
+    );
+    const hasConflict = conflictDecisions.length > 0
+        ? detectConflictWithSettings(conflictDecisions, state.ui.settings.treatMlAsManual)
         : false;
     if (state.ui.screening.isKeyOpened && hasConflict) {
         dom.conflictBanner.classList.remove('hidden');

--- a/src/sidepanel/state.ts
+++ b/src/sidepanel/state.ts
@@ -65,7 +65,7 @@ let _activeLlmExecutionIds: Set<string> = new Set();
 let _failedRefIds: string[] = [];  // リトライ対象の失敗ref_id
 let _enabledReviewers: Set<string> = new Set(); // 表示対象のレビュアーID
 let _availableReviewers: Set<string> = new Set(); // 利用可能な全レビュアーID
-let _showAiHighlights = false; // AIのEvidenceをハイライトするかどうか
+let _showAiHighlights = true; // AIのEvidenceをハイライトするかどうか（デフォルトON）
 let _aiDecisionFilter: Record<string, { include: boolean; exclude: boolean }> = {}; // AI判定の表示フィルター（AIレビュアーID別）
 let _treatMlAsManual = true; // ML判定を手動判定と同一視するか
 

--- a/src/sidepanel/store/reducer.ts
+++ b/src/sidepanel/store/reducer.ts
@@ -58,7 +58,7 @@ export const initialState: AppState = {
             showRecordCountBelow: true,
             termFilterUseAnd: true,
             treatMlAsManual: true,
-            showAiHighlights: false,
+            showAiHighlights: true,
             aiDecisionFilter: {},
             abstractSubsectionBreakEnabled: false,
             abstractSubsectionHeadings: [],

--- a/src/sidepanel/store/selectors.ts
+++ b/src/sidepanel/store/selectors.ts
@@ -8,6 +8,7 @@ import type { ReferenceWithStatus, DecisionStatus, Decision } from '../../lib/ty
 import { createSmartRegex } from '../utils/text';
 import { parseSearchQuery } from '../utils/search';
 import { isHumanDecision, isConfirmedMlDecision, isMlDecision } from '../../lib/client-version';
+import { computeReviewerKey, detectConflictWithSettings, hasEffectiveConflict } from '../render/helpers';
 import { t } from '../../lib/i18n';
 
 // ========== フィルタリング関連 ==========
@@ -50,13 +51,22 @@ export function getMyManualDecisionStatus(
 function isFulltextCandidate(
     ref: ReferenceWithStatus,
     userEmail: string,
-    treatMlAsManual: boolean
+    treatMlAsManual: boolean,
+    enabledReviewers: Set<string>,
+    isKeyOpened: boolean
 ): boolean {
     let includeCategories = 0;
 
+    // 無効化されたレビュアーの判定は無視（Blind OFF 時のみ）
+    const isReviewerEnabled = (d: Decision): boolean => {
+        if (!isKeyOpened) return true;
+        const key = computeReviewerKey(d, treatMlAsManual);
+        return key !== '' && enabledReviewers.has(key);
+    };
+
     const hasInclude = (check: (d: Decision) => boolean) => {
-        return (ref.allDecisions?.some(d => check(d) && d.decision === 'include')) ||
-            (ref.myDecision && check(ref.myDecision) && ref.myDecision.decision === 'include');
+        return (ref.allDecisions?.some(d => isReviewerEnabled(d) && check(d) && d.decision === 'include')) ||
+            (ref.myDecision && isReviewerEnabled(ref.myDecision) && check(ref.myDecision) && ref.myDecision.decision === 'include');
     };
 
     // 1. 手動判定
@@ -79,7 +89,7 @@ function isFulltextCandidate(
 
     // 3. LLM判定
     const llmInclude = ref.allDecisions?.some(d =>
-        d.reviewer_id.startsWith('llm:') && d.decision === 'include'
+        d.reviewer_id.startsWith('llm:') && d.decision === 'include' && isReviewerEnabled(d)
     );
     if (llmInclude) includeCategories++;
 
@@ -97,10 +107,12 @@ export function getFilteredReferences(state: AppState): ReferenceWithStatus[] {
     // ステータスフィルター
     if (screening.currentFilter === 'fulltext_candidates') {
         filtered = filtered.filter(r =>
-            isFulltextCandidate(r, data.userEmail, settings.treatMlAsManual)
+            isFulltextCandidate(r, data.userEmail, settings.treatMlAsManual, data.enabledReviewers, screening.isKeyOpened)
         );
     } else if (screening.currentFilter === 'conflict') {
-        filtered = filtered.filter(r => r.status === 'conflict');
+        filtered = filtered.filter(r =>
+            hasEffectiveConflict(r, data.enabledReviewers, screening.isKeyOpened, settings.treatMlAsManual)
+        );
     } else if (screening.currentFilter !== 'all') {
         filtered = filtered.filter(r =>
             getMyManualDecisionStatus(r, data.userEmail, settings.treatMlAsManual) === screening.currentFilter
@@ -158,19 +170,22 @@ export function getFilteredReferences(state: AppState): ReferenceWithStatus[] {
         }
     }
 
-    // AI判定フィルター (Blind off時のみ、AIレビュアーごとに独立して適用)
+    // 判定フィルター (Blind off時のみ、レビュアーごとに独立して適用)
     if (screening.isKeyOpened) {
         for (const [reviewerId, filter] of Object.entries(settings.aiDecisionFilter)) {
+            // 無効化されたレビュアーはフィルター対象外
+            if (!data.enabledReviewers.has(reviewerId)) continue;
+
             const allowed = new Set<string>();
             if (filter.include) allowed.add('include');
             if (filter.exclude) allowed.add('exclude');
-            // 両方ON or 両方OFF はこのAIのフィルターを適用しない
+            // 両方ON or 両方OFF はこのレビュアーのフィルターを適用しない
             if (allowed.size === 2 || allowed.size === 0) continue;
 
             filtered = filtered.filter(r => {
-                const aiDecision = r.allDecisions?.find(d => d.reviewer_id === reviewerId);
-                if (!aiDecision) return false; // 該当AIの判定が無いレコードは非表示
-                return allowed.has(aiDecision.decision);
+                const decision = r.allDecisions?.find(d => d.reviewer_id === reviewerId);
+                if (!decision) return false; // 該当レビュアーの判定が無いレコードは非表示
+                return allowed.has(decision.decision);
             });
         }
     }
@@ -238,9 +253,11 @@ export function getFilterCounts(state: AppState): {
         include: filtered.filter(r => getStatus(r) === 'include').length,
         exclude: filtered.filter(r => getStatus(r) === 'exclude').length,
         maybe: filtered.filter(r => getStatus(r) === 'maybe').length,
-        conflict: filtered.filter(r => r.status === 'conflict').length,
+        conflict: filtered.filter(r =>
+            hasEffectiveConflict(r, data.enabledReviewers, ui.screening.isKeyOpened, ui.settings.treatMlAsManual)
+        ).length,
         fulltextCandidates: filtered.filter(r =>
-            isFulltextCandidate(r, data.userEmail, ui.settings.treatMlAsManual)
+            isFulltextCandidate(r, data.userEmail, ui.settings.treatMlAsManual, data.enabledReviewers, ui.screening.isKeyOpened)
         ).length,
     };
 }


### PR DESCRIPTION
@
## 概要
スクリーニングサイドパネルの状態管理・フィルタリング周りのリファクタと、AI根拠ハイライト機能の表示制御変更をまとめたPRです。

## 変更内容

### 1. AI根拠ハイライトを全ユーザー表示＋デフォルトON (`81de5dc`)
- これまで管理者（オーナー）にしか表示されなかった「💡 AIの根拠をハイライト」チェックボックスを**全ユーザーに表示**するよう変更。
  - `loadDataAndShowScreening()` 内で `_renderAiHighlightToggle()` の呼び出しを `if (adminStatus)` ブロックの外へ移動。
  - 確定済みAI判定が存在するプロジェクトでのみ表示される既存のガードは維持。
- `showAiHighlights` の初期値を `false → true` に変更し、**デフォルトでON**に（`reducer.ts` の initialState と legacy `state.ts` の両方）。

### 2. スクリーニングのフィルタ/状態計算/進捗ロジック (`6db63a5`)
- 参照フィルタリング・ステータス計算・進捗トラッキングロジックの実装/整理。
- `filters.ts` / `reviewer-filter.ts` / `selectors.ts` / `render/helpers.ts` などのリファクタ。

## 動作確認
- `npm run build` 成功（型エラーなし。警告はバンドルサイズの既存のもののみ）。
- 一般ユーザー（非admin）アカウントで、確定AI判定のあるプロジェクトを開き、チェックボックスが表示され・最初からONになりハイライトが描画されること。
- 確定AI判定の無いプロジェクトでは非表示のままであること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@