### PR TITLE
chore: bump version 0.20.2 -> 0.20.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tiab-review-plugin",
-    "version": "0.20.2",
+    "version": "0.20.3",
     "description": "TiAb Review Plugin - Chrome Extension for Systematic Review Screening",
     "private": true,
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extName__",
-    "version": "0.20.2",
+    "version": "0.20.3",
     "default_locale": "ja",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxleBKT1/T3XzlZhHEB2GjyDLIkQ8exz7ZfAx7IvDB6PMWnrwJ6Cv9SPqAJ9FxF3OSGcobjwQzYt+xBbXVZgBuvcj1mvIekDZ3jH0QeZH8HWVKAjHkGJdiAMocrR1TsOO9bAUyFiYv/R8/4/qk+b9jve0aosK2PPb80+p4GekjhDVXRVfg6Q7gKjbZitR2g/MGCQH+qHOAusyYrjoE62luQC9EfIPYxAJ4XFtxsfhOcDal990Ln9w8pchQGHjoWDc+D74LHhl2umc+9GbEXj78m5fO2CRJgTU+ETH/vIdmDi4QgmzLMkw2GWAXr/TSUenIigMAdexpDYPL+nqHk8LCwIDAQAB",
     "description": "__MSG_extDescription__",

--- a/src/sidepanel/sidepanel.html
+++ b/src/sidepanel/sidepanel.html
@@ -14,7 +14,7 @@
         <header class="header">
             <div id="header-title" class="header-title" style="cursor: pointer;" data-i18n-title="nav_backToProject">
                 <h1>TiAb Review</h1>
-                <span class="build-version">Build: 2026-05-26</span>
+                <span class="build-version">Build: 2026-05-30</span>
             </div>
             <div class="header-tabs hidden">
                 <button id="tab-screening" class="tab-btn active" data-i18n-title="nav_tabManualTitle" data-i18n="nav_tabManual"></button>


### PR DESCRIPTION
リリースビルド（テスター向けGoogle Drive配布）に伴うバージョンバンプです。

## 内容
- `package.json` / `src/manifest.json`: 0.20.2 → **0.20.3**
- `src/sidepanel/sidepanel.html`: Build日付を **2026-05-30** に更新

## 備考
- リリース成果物（`dist.zip` 0.20.3）はビルド済みで、Drive配布フォルダへコピー済みです。
- このリリースには #15（AI根拠ハイライトの全ユーザー表示＋デフォルトON）が含まれます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)